### PR TITLE
Wire 6 agent prompts to invoke analysis scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - .gitignore (Python template).
 - Test suite for all 6 plugin scripts (116 tests).
 
+### Enhanced
+
+- 6 agent prompts now invoke their corresponding analysis scripts for precise, machine-verified data before qualitative analysis: architecture-mapper, complexity-simplifier, test-coverage-analyzer, tech-debt-inventory, type-design-analyzer, dead-code-finder.
+
 ### Fixed
 
 - Test helper `_SCRIPTS_DIR` path to point to `plugins/code-review-toolkit/scripts/`.

--- a/plugins/code-review-toolkit/agents/architecture-mapper.md
+++ b/plugins/code-review-toolkit/agents/architecture-mapper.md
@@ -11,59 +11,74 @@ You are an expert software architect specializing in Python project structure an
 
 Analyze the scope provided. Default: the entire project. The user may specify a directory, file, or glob pattern.
 
+## Script-Assisted Analysis
+
+Before starting your qualitative analysis, run the import analysis script to get structured dependency data:
+
+```bash
+python <plugin_root>/scripts/analyze_imports.py [scope]
+```
+
+where `<plugin_root>` is the root of the code-review-toolkit plugin directory.
+
+Parse the JSON output. This gives you the complete import graph, dependency edges, fan-in/fan-out metrics, circular dependency detection, and `__init__.py` re-export data. Use this as your factual foundation — do not re-derive these metrics manually.
+
+Key fields:
+- `internal_graph`: dependency edges between project modules
+- `metrics.fan_in` / `metrics.fan_out`: coupling data per file
+- `cycles`: detected circular dependencies (you assess severity)
+- `re_exports`: `__init__.py` and `__all__` data
+- `files[].imports[]`: per-file imports with `category`, `is_relative`, `type_checking_only`, and `conditional` classification
+- `external_dependencies`: third-party packages and which files use them
+
 ## Analysis Strategy
 
-You will analyze the codebase **statically** — by reading files and parsing imports, not by executing code. Follow this process:
+You will combine script output with manual file exploration to build a complete architectural picture. Follow this process:
 
 ### Step 1: Map the Project Layout
 
-Use `find` and file listing to build a picture of the project:
+Use `find` and file listing to build a picture of the project — the script covers Python imports but not project organization:
 - Top-level package(s) and their `__init__.py` files
 - Directory tree showing packages, modules, and non-code files
 - Identify the entry points (CLI scripts, `__main__.py`, console_scripts in setup.cfg/pyproject.toml)
 - Identify test directories and their structure relative to source
 - Note configuration files (pyproject.toml, setup.cfg, CLAUDE.md, etc.)
 
-### Step 2: Build the Dependency Graph
+### Step 2: Review the Dependency Graph
 
-For each Python source file in scope, extract imports:
-- `import X` and `from X import Y` statements
-- Relative imports (`from . import`, `from ..module import`)
-- Conditional imports (`try/except ImportError`)
-- `TYPE_CHECKING`-guarded imports (note these separately — they're type-only)
-- Re-exports through `__init__.py` and `__all__`
-
-Categorize each dependency as:
-- **Internal**: Between modules within the project
-- **Stdlib**: Python standard library
-- **External**: Third-party packages
-
-Focus your analysis on **internal** dependencies — these define the architecture.
+The script output provides the complete internal dependency graph, import categorization (stdlib/internal/external), and per-file import details including TYPE_CHECKING and conditional classifications. Review `internal_graph` and `files` for:
+- The shape of internal dependencies — which modules depend on which
+- Relative vs. absolute import patterns
+- TYPE_CHECKING-guarded imports (type-only, no runtime dependency)
+- Conditional imports (try/except ImportError)
+- Re-exports through `__init__.py` and `__all__` (from `re_exports`)
 
 ### Step 3: Identify Module Boundaries
 
-Determine the logical modules (not just directories):
+Using the dependency graph from the script, determine the logical modules:
 - What responsibility does each package/module own?
 - Which modules form cohesive units?
 - Where are the natural boundaries between subsystems?
-- Which `__init__.py` files define a public API vs. just re-export everything?
+- Which `__init__.py` files define a public API vs. just re-export everything? (Check `re_exports` for `__all__` declarations.)
 
 ### Step 4: Detect Structural Issues
 
-Look for these specific problems:
+The script provides the raw data; apply your judgment to assess significance:
 
 **Circular dependencies:**
-- Direct cycles (A→B→A)
-- Indirect cycles (A→B→C→A)
-- Note which are import-time vs. runtime-only (TYPE_CHECKING)
-- Assess severity: does the cycle cause actual import failures or just indicate poor layering?
+- The script's `cycles` field lists detected cycles. For each, assess:
+- Is the cycle import-time or runtime-only? (Check `type_checking_only` on the edges.)
+- Does it cause actual import failures or just indicate poor layering?
+- Rate severity accordingly.
 
 **Layering violations:**
+- Use `internal_graph` to identify direction problems:
 - Utility/infrastructure modules importing from feature modules
 - Low-level modules depending on high-level modules
 - Test utilities importing from test cases instead of source
 
 **Coupling hotspots:**
+- The script's `metrics.fan_in` and `metrics.fan_out` provide precise counts:
 - Modules with unusually high fan-in (many dependents — fragile to change)
 - Modules with unusually high fan-out (many dependencies — doing too much?)
 - God modules that everything imports from
@@ -104,10 +119,10 @@ Structure your output as follows:
   module_b → module_d (what it uses)
 
 ### High Fan-In Modules (most depended-on)
-[List modules with the most internal dependents, ranked. These are the foundational modules.]
+[From script metrics.fan_in — list modules with the most internal dependents, ranked. These are the foundational modules.]
 
 ### High Fan-Out Modules (most dependencies)
-[List modules with the most internal dependencies, ranked. These may be doing too much.]
+[From script metrics.fan_out — list modules with the most internal dependencies, ranked. These may be doing too much.]
 
 ## Structural Issues
 

--- a/plugins/code-review-toolkit/agents/complexity-simplifier.md
+++ b/plugins/code-review-toolkit/agents/complexity-simplifier.md
@@ -11,39 +11,57 @@ You are an expert in code complexity analysis and simplification for Python code
 
 Analyze the scope provided. Default: the entire project. You may receive architecture-mapper output as additional context — use it to understand which complex code is in high-traffic modules (making complexity more costly) vs. isolated modules (where complexity is more tolerable).
 
+## Script-Assisted Analysis
+
+Before starting your qualitative analysis, run the complexity measurement script:
+
+```bash
+python <plugin_root>/scripts/measure_complexity.py [scope]
+```
+
+where `<plugin_root>` is the root of the code-review-toolkit plugin directory.
+
+Parse the JSON output. This gives you precise per-function metrics and pre-computed complexity scores. Use this as your factual foundation — do not re-derive these metrics manually.
+
+Key fields:
+- `hotspots`: pre-ranked list of functions scoring ≥ 5 (up to 30)
+- `summary`: aggregate statistics (total functions, hotspot counts, average scores)
+- Per-function `metrics`: `line_count`, `nesting_depth`, `parameter_count`, `branch_count`, `loop_count`, `return_count`, `local_variable_count`, `cognitive_complexity`
+- Per-function `score`: pre-computed 1-10 complexity rating
+
 ## Analysis Strategy
 
-### Step 1: Measure Complexity
+### Step 1: Review Complexity Data
 
-For each function and method in scope, assess these dimensions:
+The script output provides all structural metrics per function. Review the data, focusing on:
 
-**Structural Complexity:**
-- **Nesting depth**: Maximum indentation level within the function (if/for/try/with nesting)
-- **Function length**: Lines of code (excluding blank lines and comments)
-- **Parameter count**: Number of parameters including *args/**kwargs
-- **Branch count**: Number of if/elif/else/match-case branches
-- **Loop complexity**: Nested loops, loops with complex break/continue logic
+**Structural Complexity** (from script metrics):
+- **Nesting depth**: `metrics.nesting_depth`
+- **Function length**: `metrics.line_count` (excluding blanks and comments)
+- **Parameter count**: `metrics.parameter_count` (excluding self/cls)
+- **Branch count**: `metrics.branch_count`
+- **Loop complexity**: `metrics.loop_count`
 
-**Cognitive Complexity:**
+**Cognitive Complexity** — supplement the script's `metrics.cognitive_complexity` score with your qualitative assessment of:
 - **State tracking**: How many variables must be mentally tracked through the function?
 - **Control flow surprises**: Early returns mixed with late returns, exceptions used for control flow, deeply nested conditionals
 - **Abstraction mismatch**: Function operates at multiple levels of abstraction simultaneously (e.g., both parsing bytes and making business decisions)
 - **Boolean complexity**: Complex boolean expressions, double negations, boolean parameters that change behavior
 
-**Maintenance Complexity:**
+**Maintenance Complexity** (purely qualitative — read the code):
 - **Coupling**: How many other modules/functions does this function depend on?
 - **Side effects**: Does it modify global state, write files, make network calls?
 - **Implicit contracts**: Does it depend on specific call ordering, global state, or undocumented preconditions?
 
-### Step 2: Rank Hotspots
+### Step 2: Refine Hotspot Rankings
 
-Produce a ranked list of the most complex functions/methods. The ranking should consider:
+The script provides `hotspots` pre-ranked by score. Review the rankings to see if the scores feel right — the scoring formula is mechanical, and you may want to adjust based on context (e.g., "this function is complex but it's a parser, so that's inherent"). Consider:
 
-1. **Absolute complexity**: How complex is this function on its own?
+1. **Absolute complexity**: The script's `score` field captures this.
 2. **Relative importance**: Is it in a frequently-modified module? Is it a core function that many things depend on? (Use architecture-mapper output if available.)
 3. **Simplification potential**: Can this complexity actually be reduced, or is it inherent to the problem domain?
 
-Rate each hotspot on a 1-10 **complexity score** where:
+The score scale:
 - 1-3: Normal complexity, no action needed
 - 4-5: Moderate — worth simplifying if you're already touching this code
 - 6-7: High — should be simplified proactively
@@ -104,7 +122,7 @@ For each suggestion, verify:
 
 [2-3 sentence summary: How complex is this codebase overall? Where does complexity concentrate? Is complexity proportional to problem difficulty?]
 
-### Complexity Distribution
+### Complexity Distribution (from script summary)
 - Files analyzed: N
 - Functions/methods analyzed: N
 - Hotspots (score ≥5): N

--- a/plugins/code-review-toolkit/agents/dead-code-finder.md
+++ b/plugins/code-review-toolkit/agents/dead-code-finder.md
@@ -13,42 +13,58 @@ Dead code is dangerous not because it runs, but because it doesn't: developers w
 
 Analyze the scope provided. Default: the entire project. Architecture-mapper output helps identify module boundaries and import patterns.
 
+## Script-Assisted Analysis
+
+Before starting your qualitative analysis, run the dead symbol finder script:
+
+```bash
+python <plugin_root>/scripts/find_dead_symbols.py [scope]
+```
+
+where `<plugin_root>` is the root of the code-review-toolkit plugin directory.
+
+Parse the JSON output. This gives you unused imports, unreferenced functions/classes, orphan files, and commented-out code blocks — all with confidence ratings. Use this as your factual foundation, then focus your effort on **verification and false-positive filtering**.
+
+Key fields:
+- `unused_imports`: with `confidence` ratings, accounting for `__all__` and `__init__.py` re-exports
+- `unreferenced_symbols`: with `confidence` ratings, accounting for magic methods, test discovery, and `__main__` guards
+- `orphan_files`: with `confidence` ratings
+- `commented_code_blocks`: with line ranges and previews
+- `summary`: aggregate counts for each category plus high/medium confidence totals
+
 ## What to Search For
 
 ### Unused Imports
-- Imports at the top of a file that are never referenced in the file body
-- Note: `TYPE_CHECKING`-guarded imports are only used by type checkers — verify they're referenced in annotations
-- Note: `__init__.py` imports may be re-exports — check if they're in `__all__` or used by external modules
+The script's `unused_imports` identifies imports never referenced in the file body, already accounting for `__all__` re-exports and `__init__.py` patterns. Review the findings — especially medium-confidence items where `TYPE_CHECKING`-guarded imports may need verification against annotations.
 
 ### Unreferenced Functions and Classes
-- Functions/methods defined but never called from anywhere in the codebase
-- Classes defined but never instantiated or subclassed
-- Check: entry points (CLI commands, test cases, __main__) — these won't have callers but aren't dead
-- Check: `__all__` exports — listed items are part of the public API even without internal callers
-- Check: registered callbacks, decorators, and plugin hooks — these may be called dynamically
+The script's `unreferenced_symbols` lists functions/classes defined but never referenced anywhere in the codebase. The script already excludes magic methods, test methods, setUp/tearDown, `__all__` entries, and `__main__`-guarded functions. Review medium-confidence items especially for:
+- Registered callbacks, decorators, and plugin hooks — these may be called dynamically
+- Classes that may be instantiated by deserializers or frameworks
 
 ### Orphan Files
-- Python files that are never imported by any other file in the project
-- Exceptions: entry points, test files, __main__.py, scripts referenced in pyproject.toml/setup.cfg
+The script's `orphan_files` lists Python files never imported by any other file, already excluding entry points, test files, `__init__.py`, and setup files. Review each to confirm they're genuinely unused.
 
 ### Unreachable Code
+Not covered by the script — check manually:
 - Code after unconditional `return`, `raise`, `break`, `continue`
 - Branches guarded by always-true or always-false conditions (if constants are deterministic)
 - `else` branches after `if` blocks that always return/raise
 
 ### Stale Conditional Code
+Not covered by the script — check manually:
 - `if False:` blocks or `if 0:` blocks
 - Feature flags or environment variable checks for features that appear to be always on/off
 - Platform checks for platforms the project doesn't support
 - Version checks for Python versions below the project's minimum
 
 ### Unused Variables
+Not covered by the script — check manually:
 - Variables assigned but never read (especially in loops or conditional blocks)
 - Caught exception variables that are never used (`except SomeError as e:` where `e` is unused)
 
 ### Commented-Out Code
-- Significant blocks of commented-out code (as opposed to documentation comments)
-- Code in triple-quoted strings that looks like it was disabled rather than documented
+The script's `commented_code_blocks` identifies significant blocks of commented-out code (3+ consecutive lines matching code patterns). Review each block — the script distinguishes code from documentation comments.
 
 ## False Positive Avoidance
 
@@ -78,11 +94,11 @@ For each finding, rate your **confidence** that it's genuinely dead:
 
 [2-3 sentence overview: How clean is the codebase? Estimated volume of dead code.]
 
-### Statistics
+### Statistics (from script summary, plus manual checks)
 - Unused imports: N (across N files)
 - Unreferenced functions/classes: N
 - Orphan files: N
-- Unreachable code blocks: N
+- Unreachable code blocks: N (manual check)
 - Commented-out code blocks: N
 
 ## High Confidence (safe to remove)

--- a/plugins/code-review-toolkit/agents/tech-debt-inventory.md
+++ b/plugins/code-review-toolkit/agents/tech-debt-inventory.md
@@ -11,11 +11,30 @@ You are a technical debt cataloger for Python codebases. Your mission is to prod
 
 Analyze the scope provided. Default: the entire project.
 
+## Script-Assisted Analysis
+
+Before starting your qualitative analysis, run the debt collection script:
+
+```bash
+python <plugin_root>/scripts/collect_debt.py [scope]
+```
+
+where `<plugin_root>` is the root of the code-review-toolkit plugin directory.
+
+Parse the JSON output. This gives you all explicit debt markers with full text, file/line locations, surrounding context, git blame author/date, and age classification. Use this as your factual foundation — do not re-grep for these markers manually.
+
+Key fields:
+- `items`: complete list of markers, each with `category`, `text`, `full_line`, `context_before`, `context_after`, `age`, `author`, `date`
+- `summary.total_markers`: total count
+- `summary.by_category`: counts per category (TODO, FIXME, HACK, XXX, NOQA, TYPE_IGNORE, PRAGMA_NO_COVER, SKIP)
+- `summary.by_age`: counts per age bucket (fresh/growing/stale/ancient/unknown)
+- `summary.top_files`: files with the most debt markers
+
 ## What to Catalog
 
 ### Explicit Debt Markers
 
-Search for these patterns in source AND test files:
+The script output provides a comprehensive scan for these patterns in source AND test files:
 
 - `TODO`: Planned work that hasn't been done
 - `FIXME`: Known bugs or problems to fix
@@ -25,11 +44,7 @@ Search for these patterns in source AND test files:
 - `pragma: no cover`: Deliberately untested code
 - `@unittest.skip` / `@pytest.mark.skip`: Disabled tests
 
-For each, extract:
-- The full comment text
-- File and line number
-- Author and age (from `git blame` if available)
-- Surrounding context (what code is this attached to?)
+The script extracts full text, file/line, author/age (via git blame), and surrounding context for each marker. Review the `items` list — your role is to assess priority and context, not re-collect the data.
 
 ### Implicit Debt
 
@@ -80,7 +95,7 @@ If git is available, use `git blame` to assess debt age:
 
 [2-3 sentence summary: volume of debt, age distribution, biggest categories]
 
-### Statistics
+### Statistics (from script summary)
 - Total explicit markers: N
   - TODO: N | FIXME: N | HACK: N | XXX: N
   - type:ignore: N | noqa: N | pragma:no-cover: N | skip: N

--- a/plugins/code-review-toolkit/agents/test-coverage-analyzer.md
+++ b/plugins/code-review-toolkit/agents/test-coverage-analyzer.md
@@ -11,16 +11,34 @@ You are an expert test coverage analyst for Python codebases. Your mission is to
 
 Analyze the scope provided. Default: the entire project. You may receive architecture-mapper output — use it to understand which modules are most critical (high fan-in modules need better coverage).
 
+## Script-Assisted Analysis
+
+Before starting your qualitative analysis, run the test correlation script:
+
+```bash
+python <plugin_root>/scripts/correlate_tests.py [scope]
+```
+
+where `<plugin_root>` is the root of the code-review-toolkit plugin directory.
+
+Parse the JSON output. This gives you the complete source↔test file mapping, test method counts, untested modules, and public API surface sizes. Use this as your factual foundation — do not re-derive the mapping manually.
+
+Key fields:
+- `untested_sources`: source files with no corresponding tests
+- `source_coverage`: per-file test correspondence with `test_method_count`, `public_surface_size`, `has_tests`
+- `summary`: aggregate statistics (source files, test files, coverage percentage, total test methods, skipped tests)
+- `test_details`: per-test-file class/method inventory including `skipped_methods`
+
 ## Analysis Strategy
 
-### Step 1: Map Source to Tests
+### Step 1: Review Source-to-Test Mapping
 
-Build a correspondence map:
-- For each source module, identify its corresponding test file(s)
-- Note the mapping convention (e.g., `src/runner.py` → `tests/test_runner.py`)
-- Identify source modules with **no corresponding test file**
-- Identify test files that don't correspond to a specific source module (integration tests, end-to-end tests)
-- Count test classes and test methods per source module
+The script output provides the complete correspondence map. Review `source_coverage` and `untested_sources` for:
+- The mapping convention used (e.g., `src/runner.py` → `tests/test_runner.py`)
+- Source modules with **no corresponding test file** (from `untested_sources`)
+- Test files that don't correspond to a specific source module (integration tests, end-to-end tests — check `test_details` for unmatched test files)
+- Test classes and test methods per source module (from `source_coverage[].test_method_count`)
+- Skipped test counts (from `summary.total_skipped_tests` and per-class `skipped_methods`)
 
 ### Step 2: Assess Coverage Quality
 
@@ -70,7 +88,7 @@ Assess the overall test suite structure:
 
 [2-3 sentence summary: overall coverage quality, biggest gaps, testing maturity level]
 
-### Source/Test Correspondence
+### Source/Test Correspondence (from script summary)
 - Source modules: N
 - Test files: N
 - Modules with tests: N (X%)

--- a/plugins/code-review-toolkit/agents/type-design-analyzer.md
+++ b/plugins/code-review-toolkit/agents/type-design-analyzer.md
@@ -13,17 +13,35 @@ Python's type system is different from TypeScript or Java — it's gradual, opti
 
 Analyze the scope provided. Default: the entire project. Architecture-mapper output helps identify which modules form the public API (where types matter most).
 
+## Script-Assisted Analysis
+
+Before starting your qualitative analysis, run the type counting script:
+
+```bash
+python <plugin_root>/scripts/count_types.py [scope]
+```
+
+where `<plugin_root>` is the root of the code-review-toolkit plugin directory.
+
+Parse the JSON output. This gives you precise annotation coverage statistics, Any usage locations, type:ignore counts, data container inventory, and unannotated public function lists. Use this as your factual foundation — do not re-count annotations manually.
+
+Key fields:
+- `summary`: coverage percentages (`annotation_coverage_all`, `annotation_coverage_public`), counts of functions/classes/Any usages/type ignores, container type breakdown
+- `any_usages`: locations and details of every Any usage
+- `container_inventory`: categorized data containers (dataclass, TypedDict, NamedTuple, Protocol, Enum)
+- `unannotated_public_functions`: priority annotation targets (up to 50)
+- `files[]`: per-file details including per-function annotation status and class attribute analysis
+
 ## Analysis Framework
 
 ### 1. Type Hint Coverage
 
-Survey annotation status:
-- **Function signatures**: What percentage of functions have parameter and return type annotations?
-- **Module variables**: Are module-level constants and variables annotated?
-- **Class attributes**: Are class attributes annotated (especially in `__init__`)?
-- **Coverage distribution**: Is annotation concentrated in some modules and absent in others?
+The script output provides precise coverage statistics. Review `summary` for:
+- **Function signatures**: `annotation_coverage_all` and `annotation_coverage_public` give exact percentages
+- **Class attributes**: Per-class `annotated_attributes` and `unannotated_attributes` in the file details
+- **Coverage distribution**: Compare per-file data to identify modules with concentrated gaps
 
-Classify each unannotated public function as:
+Using `unannotated_public_functions` from the script, classify each as:
 - **Should annotate**: Function is part of public API or has non-obvious types
 - **Nice to annotate**: Internal function that would benefit from clarity
 - **Can skip**: Simple, obvious function where annotations add noise
@@ -54,20 +72,20 @@ For each significant type (dataclass, TypedDict, NamedTuple, Protocol, class wit
 
 ### 3. Type Anti-Patterns
 
-Flag these Python-specific issues:
+The script provides data for several anti-patterns; apply your judgment to assess which matter:
 
-- **`Any` overuse**: Where `Any` is used as an escape hatch when a more specific type is feasible
+- **`Any` overuse**: The script's `any_usages` lists every location. Review each to determine if a more specific type is feasible.
 - **`dict` as catch-all**: Using `Dict[str, Any]` when a TypedDict or dataclass would be clearer
 - **Tuple overload**: Using `Tuple[str, int, bool, str]` when a NamedTuple or dataclass would give names to fields
 - **Optional everywhere**: Excessive `Optional[X]` that could be eliminated with better API design
 - **String typing**: Using string literals where an Enum or Literal type would constrain values
-- **Type: ignore proliferation**: Many `# type: ignore` comments indicating a type system mismatch
-- **Untyped containers**: `list`, `dict`, `set` without type parameters
+- **Type: ignore proliferation**: The script's `summary.total_type_ignores` and per-file `type_ignore_count` give exact counts. Many comments indicate a type system mismatch.
+- **Untyped containers**: The script's `untyped_containers` lists bare `list`, `dict`, `set` without type parameters.
 - **Mutable defaults**: Mutable default arguments that could cause shared-state bugs
 
 ### 4. Data Container Choice Assessment
 
-For each data container type used, assess whether the right container was chosen:
+The script's `container_inventory` lists all data containers by type. For each, assess whether the right container was chosen:
 
 | Choice | Best For |
 |--------|----------|
@@ -95,11 +113,11 @@ Check whether typing patterns are consistent across the codebase:
 
 [2-3 sentence summary: type maturity level, coverage, quality of type design]
 
-### Coverage Statistics
+### Coverage Statistics (from script summary)
 - Functions with full signatures: N / N total (X%)
 - Classes with attribute annotations: N / N total (X%)
 - Modules with complete typing: N / N total (X%)
-- Uses of Any: N (list locations if <20)
+- Uses of Any: N (list locations if <20, from any_usages)
 - Type: ignore comments: N
 
 ## Type Design Reviews


### PR DESCRIPTION
## Summary
- Add "Script-Assisted Analysis" sections to 6 agents: architecture-mapper, complexity-simplifier, test-coverage-analyzer, tech-debt-inventory, type-design-analyzer, dead-code-finder.
- Mechanical analysis steps now reference script JSON output fields instead of instructing the agent to re-derive data.
- All qualitative analysis, YAML frontmatter, output format structure, and guidelines preserved unchanged.

## Test plan
- [x] All 6 agents have Script-Assisted Analysis section with correct script name
- [x] YAML frontmatter (name, description, model, color) unchanged in all 6 files
- [x] Script field references match actual JSON output keys verified against script source
- [x] Qualitative analysis steps preserved
- [x] All 116 tests pass
- [x] CHANGELOG updated

Closes #7

Generated with [Claude Code](https://claude.com/claude-code)