### PR TITLE
Add installation instructions and marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "code-review-toolkit",
+  "version": "1.0.0",
+  "description": "Codebase exploration and analysis toolkit: 14 specialized agents for architecture mapping, git history analysis, consistency auditing, complexity analysis, test coverage, error handling, documentation, type design, dead code detection, tech debt inventory, pattern consistency, and API surface review.",
+  "owner": {
+    "name": "Danzin",
+    "email": "lafleurfuzzer@gmail.com"
+  },
+  "plugins": [
+    {
+      "name": "code-review-toolkit",
+      "description": "14 specialized agents and 4 commands for exploring, analyzing, and improving existing Python codebases. Includes analysis scripts for import graphing, complexity measurement, test correlation, type coverage, dead symbol detection, tech debt collection, and git history analysis.",
+      "source": "./plugins/code-review-toolkit",
+      "version": "1.0.0",
+      "category": "code-quality",
+      "keywords": [
+        "code-review",
+        "code-quality",
+        "architecture",
+        "complexity",
+        "testing",
+        "documentation",
+        "python",
+        "analysis",
+        "refactoring",
+        "tech-debt"
+      ]
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Marketplace file (`.claude-plugin/marketplace.json`) for plugin discovery and installation.
+- Installation instructions in both top-level README and plugin README (marketplace, direct, local, and manual methods).
+- Prerequisites section documenting Python 3.10+ and Git requirements.
 - Task-workflow skill for standardized development workflow (issue, branch, code, test, commit, PR, merge).
 - CHANGELOG.md to track all notable changes.
 - README.md with overview, quick start, and links to detailed plugin docs.

--- a/README.md
+++ b/README.md
@@ -2,22 +2,69 @@
 
 A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugin that bundles 14 specialized agents and 4 commands for exploring and analyzing existing codebases. It answers the question: **where are the problems in this codebase, and what should I fix first?**
 
-## Quick Start
+## Installation
 
-Install the plugin, then run:
+### From the marketplace (recommended)
+
+Add this repository as a Claude Code marketplace, then install the plugin:
 
 ```bash
-/code-review-toolkit:map        # Understand structure
+# Add the marketplace (one-time setup)
+claude plugin marketplace add devdanzin/code-review-toolkit
+
+# Install the plugin
+claude plugin install code-review-toolkit@code-review-toolkit
+```
+
+Or use the interactive plugin manager:
+
+```bash
+# Open the plugin manager
+/plugin
+
+# Go to the Discover tab, find code-review-toolkit, and install
+```
+
+### Direct install from GitHub
+
+Install the plugin directly without adding the marketplace:
+
+```bash
+claude plugin install code-review-toolkit --source github:devdanzin/code-review-toolkit --path plugins/code-review-toolkit
+```
+
+### Without installing (try it first)
+
+Clone the repo and point Claude Code at it manually — useful for trying the toolkit before committing to installation, or for development:
+
+```bash
+# Clone the repository
+git clone https://github.com/devdanzin/code-review-toolkit.git
+
+# In Claude Code, install from the local path
+/plugin install plugins/code-review-toolkit
+```
+
+Or simply copy the `plugins/code-review-toolkit/` directory into your project's `.claude/plugins/` directory.
+
+## Quick Start
+
+After installation, these commands are immediately available in Claude Code:
+
+```bash
+/code-review-toolkit:map        # Understand project structure
 /code-review-toolkit:health     # Quick health assessment
 /code-review-toolkit:hotspots   # Find cleanup targets
-/code-review-toolkit:explore    # Full exploration (all 14 agents)
+/code-review-toolkit:explore    # Full exploration (all agents)
 ```
+
+For your first time, start with `map` to understand the architecture, then `health` for a quick overview, then drill into specific areas with `explore`.
 
 ## What's Included
 
 - **14 analysis agents** covering architecture, git history context, consistency, complexity, test coverage, error handling, documentation, project documentation accuracy, type design, dead code, tech debt, pattern consistency, API surface review, and git history analysis (fix propagation, churn×quality risk).
 - **4 commands** (`explore`, `map`, `hotspots`, `health`) for different analysis workflows.
-- **Helper scripts** for complexity measurement, import analysis, dead symbol detection, test correlation, type counting, debt collection, and git history analysis.
+- **7 helper scripts** for complexity measurement, import analysis, dead symbol detection, test correlation, type counting, debt collection, and git history analysis.
 
 For detailed usage, agent descriptions, and recommended workflows, see the [plugin README](plugins/code-review-toolkit/README.md).
 

--- a/plugins/code-review-toolkit/README.md
+++ b/plugins/code-review-toolkit/README.md
@@ -13,6 +13,69 @@ This plugin bundles 14 expert analysis agents and 4 commands. Each agent focuses
 - **Prioritized output**: Each agent caps its output to avoid overwhelming reports, ranking by severity and offering deeper analysis on request
 - **Python-calibrated**: All agents are tuned for Python idioms (gradual typing, unittest, dynamic dispatch, `__init__.py` conventions, etc.)
 
+## Installation
+
+### Marketplace install
+
+This is the recommended method. It registers the repository as a Claude Code marketplace so you can install and update the plugin through the built-in plugin manager.
+
+```bash
+# Add the marketplace (one-time)
+claude plugin marketplace add devdanzin/code-review-toolkit
+
+# Install the plugin
+claude plugin install code-review-toolkit@code-review-toolkit
+
+# Update when new versions are available
+claude plugin marketplace update
+/plugin  # Go to Updates tab
+```
+
+### Local install (for development or testing)
+
+```bash
+git clone https://github.com/devdanzin/code-review-toolkit.git
+cd code-review-toolkit
+```
+
+Then in Claude Code:
+
+```bash
+/plugin install plugins/code-review-toolkit
+```
+
+### Manual install
+
+Copy the `plugins/code-review-toolkit/` directory to one of:
+
+- **User scope** (available in all projects): `~/.claude/plugins/code-review-toolkit/`
+- **Project scope** (available in one project): `<project>/.claude/plugins/code-review-toolkit/`
+
+### Using without installing
+
+You can use the agents and commands without installing by referencing them directly. Clone the repo and tell Claude Code about the agents:
+
+```bash
+git clone https://github.com/devdanzin/code-review-toolkit.git
+```
+
+Then in Claude Code, reference agents by path:
+
+```
+Read the agent at code-review-toolkit/plugins/code-review-toolkit/agents/architecture-mapper.md
+and use it to analyze this project
+```
+
+This is less convenient than installation (no slash commands, no automatic agent triggering) but useful for one-off analysis or evaluation.
+
+### Prerequisites
+
+- **Claude Code**: The plugin requires Claude Code to be installed and running.
+- **Python 3.10+**: The analysis scripts use AST features and type syntax from Python 3.10+.
+- **Git**: Required for the git-history-context and git-history-analyzer agents, and for tech-debt-inventory's age analysis.
+
+No third-party Python packages are required — all scripts use only the standard library.
+
 ## Commands
 
 ### `/code-review-toolkit:explore [scope] [aspects] [options]`
@@ -186,25 +249,33 @@ code-review-toolkit/
 │   └── plugin.json
 ├── README.md
 ├── agents/
-│   ├── architecture-mapper.md
-│   ├── consistency-auditor.md
-│   ├── complexity-simplifier.md
-│   ├── test-coverage-analyzer.md
-│   ├── pattern-consistency-checker.md
-│   ├── silent-failure-hunter.md
-│   ├── documentation-auditor.md
-│   ├── type-design-analyzer.md
-│   ├── dead-code-finder.md
-│   ├── tech-debt-inventory.md
 │   ├── api-surface-reviewer.md
-│   ├── project-docs-auditor.md
+│   ├── architecture-mapper.md
+│   ├── complexity-simplifier.md
+│   ├── consistency-auditor.md
+│   ├── dead-code-finder.md
+│   ├── documentation-auditor.md
+│   ├── git-history-analyzer.md
 │   ├── git-history-context.md
-│   └── git-history-analyzer.md
-└── commands/
-    ├── explore.md
-    ├── map.md
-    ├── hotspots.md
-    └── health.md
+│   ├── pattern-consistency-checker.md
+│   ├── project-docs-auditor.md
+│   ├── silent-failure-hunter.md
+│   ├── tech-debt-inventory.md
+│   ├── test-coverage-analyzer.md
+│   └── type-design-analyzer.md
+├── commands/
+│   ├── explore.md
+│   ├── health.md
+│   ├── hotspots.md
+│   └── map.md
+└── scripts/
+    ├── analyze_history.py
+    ├── analyze_imports.py
+    ├── collect_debt.py
+    ├── correlate_tests.py
+    ├── count_types.py
+    ├── find_dead_symbols.py
+    └── measure_complexity.py
 ```
 
 ## Author


### PR DESCRIPTION
## Summary
- Create `.claude-plugin/marketplace.json` at repo root for plugin discovery via Claude Code's plugin manager
- Add installation instructions to both READMEs (marketplace, direct, local, manual methods + prerequisites)
- Update plugin structure tree to include scripts/ directory

## Test plan
- [x] All 161 tests pass
- [x] marketplace.json at repo root with correct `source` path
- [x] Top-level README has Installation section with 3 methods
- [x] Plugin README has Installation section with 4 methods + Prerequisites
- [x] Agent count (14) and script count (7) accurate in both READMEs
- [x] Plugin Structure tree matches actual directory
- [x] CHANGELOG updated

Closes #15

Generated with [Claude Code](https://claude.com/claude-code)