### PR TITLE
Sync cross-toolkit improvements: numbering, comment-aware triage, history perf

### DIFF
--- a/plugins/code-review-toolkit/agents/architecture-mapper.md
+++ b/plugins/code-review-toolkit/agents/architecture-mapper.md
@@ -171,3 +171,10 @@ Structure your output as follows:
 - `if TYPE_CHECKING:` imports exist solely for type checkers and don't create runtime dependencies.
 - Some projects use lazy imports for performance — note these but don't flag them as issues.
 - `__all__` explicitly defines public API — respect it when assessing what a module exposes.
+
+## Running the script
+
+- Call the script with a Bash timeout of **300000 ms** (5 min). The default 120s kills on large repos.
+- Use a **unique temp filename** for the JSON output, e.g. `/tmp/<agent-slug>_<scope>_$$.json` — the `$$` PID suffix prevents collisions when multiple agents run concurrently.
+- Forward `--max-files N` and (where supported) `--workers N` from the caller.
+- If the script **times out or errors, do NOT retry it.** Fall back to Grep/Read for the same question. Long-running runs should use `run_in_background`.

--- a/plugins/code-review-toolkit/agents/complexity-simplifier.md
+++ b/plugins/code-review-toolkit/agents/complexity-simplifier.md
@@ -233,3 +233,10 @@ For each:
 - **Decorator stacking**: More than 3 decorators on a function is a code smell. Consider whether the function has too many cross-cutting concerns.
 - **Property complexity**: `@property` methods should be trivial. Complex property getters should be explicit methods.
 - **Magic method complexity**: `__init__` should be simple assignment. Complex initialization should use classmethods as alternative constructors.
+
+## Running the script
+
+- Call the script with a Bash timeout of **300000 ms** (5 min). The default 120s kills on large repos.
+- Use a **unique temp filename** for the JSON output, e.g. `/tmp/<agent-slug>_<scope>_$$.json` — the `$$` PID suffix prevents collisions when multiple agents run concurrently.
+- Forward `--max-files N` and (where supported) `--workers N` from the caller.
+- If the script **times out or errors, do NOT retry it.** Fall back to Grep/Read for the same question. Long-running runs should use `run_in_background`.

--- a/plugins/code-review-toolkit/agents/dead-code-finder.md
+++ b/plugins/code-review-toolkit/agents/dead-code-finder.md
@@ -170,3 +170,19 @@ For each finding, rate your **confidence** that it's genuinely dead:
 - **CONSIDER**: Medium-confidence dead code that should be verified before removal — potentially dynamically referenced functions, imports that might be re-exports
 - **POLICY**: Decisions about dead code management (e.g., establish a policy on commented-out code, set up automated unused import removal)
 - **ACCEPTABLE**: Unused imports that serve as re-exports, functions referenced only via plugin/registration systems, code kept intentionally for reference
+
+## Annotations
+
+The underlying `find_dead_symbols.py` scanner is comment-aware. When a candidate finding has a nearby comment (within ±5 lines) containing one of the annotations below, the scanner either downgrades its confidence to `low` or suppresses the finding entirely. Honor these annotations in your triage — treat them as an author asserting intent.
+
+| Annotation | Effect |
+|------------|--------|
+| `# noqa` (alone or with codes) | **Suppressed entirely** (explicit lint waiver) |
+| `# SAFETY: ...` | Downgrade to `confidence: low` |
+| `# safe because ...` | Downgrade to `confidence: low` |
+| `# intentional` / `# by design` / `# deliberately` | Downgrade to `confidence: low` |
+| `# nolint` | Downgrade to `confidence: low` |
+| `# checked: ...` / `# correct because ...` | Downgrade to `confidence: low` |
+| `# this is safe` / `# not a bug` / `# expected` | Downgrade to `confidence: low` |
+
+When reporting findings, prefer to elide the low-confidence entries from your top-level list; mention only the aggregate count ("N suppressed by author annotation"). This keeps the summary focused on findings that still need human judgment.

--- a/plugins/code-review-toolkit/agents/dead-code-finder.md
+++ b/plugins/code-review-toolkit/agents/dead-code-finder.md
@@ -186,3 +186,18 @@ The underlying `find_dead_symbols.py` scanner is comment-aware. When a candidate
 | `# this is safe` / `# not a bug` / `# expected` | Downgrade to `confidence: low` |
 
 When reporting findings, prefer to elide the low-confidence entries from your top-level list; mention only the aggregate count ("N suppressed by author annotation"). This keeps the summary focused on findings that still need human judgment.
+
+## Running the script
+
+- Call the script with a Bash timeout of **300000 ms** (5 min). The default 120s kills on large repos.
+- Use a **unique temp filename** for the JSON output, e.g. `/tmp/<agent-slug>_<scope>_$$.json` — the `$$` PID suffix prevents collisions when multiple agents run concurrently.
+- Forward `--max-files N` and (where supported) `--workers N` from the caller.
+- If the script **times out or errors, do NOT retry it.** Fall back to Grep/Read for the same question. Long-running runs should use `run_in_background`.
+
+## Confidence
+
+- **HIGH** — structurally identical to a known-bad pattern, or exact signature match; ≥90% likelihood of being a true positive.
+- **MEDIUM** — similar with differences that require human verification; 70–89%.
+- **LOW** — superficially similar; requires code-context reading; 50–69%.
+
+Findings below LOW are not reported.

--- a/plugins/code-review-toolkit/agents/git-history-analyzer.md
+++ b/plugins/code-review-toolkit/agents/git-history-analyzer.md
@@ -29,6 +29,10 @@ script yourself if git-history-context output was not provided.
 
 Analyze the scope provided. Default: the entire project.
 
+## Effort Allocation
+
+Default split across the capabilities below: **60% similar-bug detection / 15% fix-completeness review / 25% churn-risk matrix** (plus incidental effort on feature review, historical annotation, and co-change coupling). Similar-bug detection is the highest-value output of this agent; fix-completeness is narrower but tractable; the churn-risk matrix is most useful when cross-referenced with other agents. Reallocate only if the caller specifies a different priority or if one phase yields no signal.
+
 ## Capability 1: Fix Completeness Review
 
 For each recent fix commit (from git-history-context's script data):
@@ -42,6 +46,16 @@ For each recent fix commit (from git-history-context's script data):
    - Was only one occurrence fixed when the pattern appears multiple times in the same file?
    - Was the symptom fixed but not the root cause?
    - Could the fix introduce a regression?
+
+### Python-specific completeness checks
+
+A fix for a Python bug is rarely complete unless it covers every branch that could reach the faulty state. Validate each recent fix against the following, not just the root cause:
+
+- **All error branches**: every `try`/`except` arm, bare `except:`, `except Exception:` fallback, and explicit error-return path (`return None`, `return False`, `return -1`, sentinel values) in the affected function. A fix that patches the happy path but leaves the `except` branch with the same bug is incomplete.
+- **All conditional branches**: platform guards (`if sys.platform == "win32":`, `if os.name == "nt":`), Python-version guards (`if sys.version_info >= (3, 11):`), feature flags, and `@unittest.skipIf` equivalents in production code. Fixes often land in one branch and miss the sibling.
+- **All affected variables**: if a fix adds validation or cleanup for `var_a`, check that `var_b` with the same pattern in the same function receives the same treatment. Refcount-style leaks, un-closed file handles, and un-released locks frequently repeat across variables within one scope.
+- **Finally/cleanup blocks**: verify that `finally` clauses and context manager `__exit__` methods also see the fix when the bug involved resource handling.
+- **Async variants**: if the fixed function has an `async def` sibling (or vice versa), check whether the async path has the same bug; `await`-based flows often diverge silently from the sync version.
 
 When the diff is truncated, use `git show HASH` to get more context if needed.
 
@@ -240,3 +254,11 @@ For each:
 - **CONSIDER**: Potentially incomplete fix, possibly vulnerable analogous code, or feature gaps (no tests, no docs)
 - **POLICY**: New feature introduces a pattern requiring a project-level decision, or co-change coupling suggests architectural restructuring
 - **ACCEPTABLE**: Fix is complete and correct, similar code is already properly handled, or co-change is natural for the module structure
+
+## Confidence
+
+- **HIGH** — structurally identical to a known-bad pattern, or exact signature match; ≥90% likelihood of being a true positive.
+- **MEDIUM** — similar with differences that require human verification; 70–89%.
+- **LOW** — superficially similar; requires code-context reading; 50–69%.
+
+Findings below LOW are not reported.

--- a/plugins/code-review-toolkit/agents/git-history-context.md
+++ b/plugins/code-review-toolkit/agents/git-history-context.md
@@ -130,3 +130,10 @@ This helps every subsequent agent prioritize — findings in volatile modules ar
 - **CONSIDER**: N/A
 - **POLICY**: N/A
 - **ACCEPTABLE**: N/A
+
+## Running the script
+
+- Call the script with a Bash timeout of **300000 ms** (5 min). The default 120s kills on large repos.
+- Use a **unique temp filename** for the JSON output, e.g. `/tmp/<agent-slug>_<scope>_$$.json` — the `$$` PID suffix prevents collisions when multiple agents run concurrently.
+- Forward `--max-files N` and (where supported) `--workers N` from the caller.
+- If the script **times out or errors, do NOT retry it.** Fall back to Grep/Read for the same question. Long-running runs should use `run_in_background`.

--- a/plugins/code-review-toolkit/agents/silent-failure-hunter.md
+++ b/plugins/code-review-toolkit/agents/silent-failure-hunter.md
@@ -219,3 +219,11 @@ For each:
 - **CONSIDER**: Error handling that works but could be improved — overly broad catches, missing traceback in logs, generic error messages
 - **POLICY**: Project-wide error handling strategy decisions (e.g., adopt a custom exception hierarchy, standardize logging levels for errors)
 - **ACCEPTABLE**: Intentional broad catches in appropriate contexts — top-level CLI handlers, cleanup code, logging utilities where suppression is the correct behavior
+
+## Confidence
+
+- **HIGH** — structurally identical to a known-bad pattern, or exact signature match; ≥90% likelihood of being a true positive.
+- **MEDIUM** — similar with differences that require human verification; 70–89%.
+- **LOW** — superficially similar; requires code-context reading; 50–69%.
+
+Findings below LOW are not reported.

--- a/plugins/code-review-toolkit/agents/tech-debt-inventory.md
+++ b/plugins/code-review-toolkit/agents/tech-debt-inventory.md
@@ -177,3 +177,19 @@ For each:
 - **CONSIDER**: Debt worth addressing proactively — growing TODOs, stale workarounds, deprecated API usage that will break on upgrade
 - **POLICY**: Debt management decisions (e.g., establish TODO format conventions, set a maximum debt age, create a cleanup sprint cadence)
 - **ACCEPTABLE**: Fresh, intentional deferrals with clear context — recent TODOs with tracking issues, type:ignore with explanatory comments, deliberate scope limitations
+
+## Annotations
+
+The underlying `collect_debt.py` scanner is comment-aware. When a debt marker has a nearby comment (within ±5 lines) containing one of the annotations below, the scanner either downgrades its confidence to `low` or suppresses the item entirely. Treat these as author assertions of intent during triage.
+
+| Annotation | Effect |
+|------------|--------|
+| `# noqa` on an adjacent line | **Suppresses the item** (explicit waiver) |
+| `# SAFETY: ...` | Downgrade to `confidence: low` |
+| `# safe because ...` | Downgrade to `confidence: low` |
+| `# intentional` / `# by design` / `# deliberately` | Downgrade to `confidence: low` |
+| `# nolint` | Downgrade to `confidence: low` |
+| `# checked: ...` / `# correct because ...` | Downgrade to `confidence: low` |
+| `# this is safe` / `# not a bug` / `# expected` | Downgrade to `confidence: low` |
+
+Items emitted with `confidence: low` are almost always classified as ACCEPTABLE in your report — the author has explicitly documented why the marker stays. Prefer to aggregate them as a single line ("N annotated markers acknowledged by authors") rather than listing them individually.

--- a/plugins/code-review-toolkit/agents/tech-debt-inventory.md
+++ b/plugins/code-review-toolkit/agents/tech-debt-inventory.md
@@ -193,3 +193,18 @@ The underlying `collect_debt.py` scanner is comment-aware. When a debt marker ha
 | `# this is safe` / `# not a bug` / `# expected` | Downgrade to `confidence: low` |
 
 Items emitted with `confidence: low` are almost always classified as ACCEPTABLE in your report — the author has explicitly documented why the marker stays. Prefer to aggregate them as a single line ("N annotated markers acknowledged by authors") rather than listing them individually.
+
+## Running the script
+
+- Call the script with a Bash timeout of **300000 ms** (5 min). The default 120s kills on large repos.
+- Use a **unique temp filename** for the JSON output, e.g. `/tmp/<agent-slug>_<scope>_$$.json` — the `$$` PID suffix prevents collisions when multiple agents run concurrently.
+- Forward `--max-files N` and (where supported) `--workers N` from the caller.
+- If the script **times out or errors, do NOT retry it.** Fall back to Grep/Read for the same question. Long-running runs should use `run_in_background`.
+
+## Confidence
+
+- **HIGH** — structurally identical to a known-bad pattern, or exact signature match; ≥90% likelihood of being a true positive.
+- **MEDIUM** — similar with differences that require human verification; 70–89%.
+- **LOW** — superficially similar; requires code-context reading; 50–69%.
+
+Findings below LOW are not reported.

--- a/plugins/code-review-toolkit/agents/test-coverage-analyzer.md
+++ b/plugins/code-review-toolkit/agents/test-coverage-analyzer.md
@@ -217,3 +217,18 @@ Note: Simple functions with obvious correctness are ACCEPTABLE even without test
 - **CONSIDER**: Untested code with moderate risk — worth adding tests but not urgent
 - **POLICY**: Testing strategy decisions that affect the whole project (e.g., adopt integration tests, set coverage targets)
 - **ACCEPTABLE**: Simple functions with obvious correctness, trivial delegation, or one-line accessors that don't need tests
+
+## Running the script
+
+- Call the script with a Bash timeout of **300000 ms** (5 min). The default 120s kills on large repos.
+- Use a **unique temp filename** for the JSON output, e.g. `/tmp/<agent-slug>_<scope>_$$.json` — the `$$` PID suffix prevents collisions when multiple agents run concurrently.
+- Forward `--max-files N` and (where supported) `--workers N` from the caller.
+- If the script **times out or errors, do NOT retry it.** Fall back to Grep/Read for the same question. Long-running runs should use `run_in_background`.
+
+## Confidence
+
+- **HIGH** — structurally identical to a known-bad pattern, or exact signature match; ≥90% likelihood of being a true positive.
+- **MEDIUM** — similar with differences that require human verification; 70–89%.
+- **LOW** — superficially similar; requires code-context reading; 50–69%.
+
+Findings below LOW are not reported.

--- a/plugins/code-review-toolkit/agents/test-investigation-agent.md
+++ b/plugins/code-review-toolkit/agents/test-investigation-agent.md
@@ -184,3 +184,18 @@ exactly what invariants to check.]
 6. **Side-by-side evidence is essential.** Every FIX finding must show the test code, the tested code where the invariant holds, and the violating code. Without this evidence, the finding is not actionable.
 
 7. **Bug-fix tests deserve the most attention.** If the script identified bug-fix tests, analyze ALL of them before moving to other tiers. A test written to prevent a regression is the strongest possible signal about what can go wrong.
+
+## Running the script
+
+- Call the script with a Bash timeout of **300000 ms** (5 min). The default 120s kills on large repos.
+- Use a **unique temp filename** for the JSON output, e.g. `/tmp/<agent-slug>_<scope>_$$.json` — the `$$` PID suffix prevents collisions when multiple agents run concurrently.
+- Forward `--max-files N` and (where supported) `--workers N` from the caller.
+- If the script **times out or errors, do NOT retry it.** Fall back to Grep/Read for the same question. Long-running runs should use `run_in_background`.
+
+## Confidence
+
+- **HIGH** — structurally identical to a known-bad pattern, or exact signature match; ≥90% likelihood of being a true positive.
+- **MEDIUM** — similar with differences that require human verification; 70–89%.
+- **LOW** — superficially similar; requires code-context reading; 50–69%.
+
+Findings below LOW are not reported.

--- a/plugins/code-review-toolkit/agents/type-design-analyzer.md
+++ b/plugins/code-review-toolkit/agents/type-design-analyzer.md
@@ -203,3 +203,10 @@ Check whether typing patterns are consistent across the codebase:
 - **CONSIDER**: Type improvements that would catch bugs or improve IDE support — adding annotations, narrowing broad types, using Protocols
 - **POLICY**: Typing strategy decisions (e.g., enable mypy strict mode, adopt `X | None` over `Optional[X]`, set annotation coverage targets)
 - **ACCEPTABLE**: Untyped private functions with obvious types, legitimate `Any` usage for genuinely dynamic data, simple internal code where annotations add noise
+
+## Running the script
+
+- Call the script with a Bash timeout of **300000 ms** (5 min). The default 120s kills on large repos.
+- Use a **unique temp filename** for the JSON output, e.g. `/tmp/<agent-slug>_<scope>_$$.json` — the `$$` PID suffix prevents collisions when multiple agents run concurrently.
+- Forward `--max-files N` and (where supported) `--workers N` from the caller.
+- If the script **times out or errors, do NOT retry it.** Fall back to Grep/Read for the same question. Long-running runs should use `run_in_background`.

--- a/plugins/code-review-toolkit/commands/explore.md
+++ b/plugins/code-review-toolkit/commands/explore.md
@@ -200,23 +200,40 @@ Before writing the summary:
 
 ## Findings by Priority
 
-### Must Fix (FIX)
-[Unambiguously wrong — bugs, crash risks, clear violations]
-- [agent(s)]: Issue description [file:line]
+**Use global non-restarting numbering**: number ALL findings sequentially across all sections. FIX findings first (1..N), then CONSIDER (N+1..M), then POLICY (M+1..P), then ACCEPTABLE (P+1..Q). Use these same numbers in the action plan. This makes it easy to reference "Finding 37" in issue trackers, code review comments, and follow-up discussions.
 
-### Should Consider (CONSIDER)
+### Must Fix (FIX) — N
+[Unambiguously wrong — bugs, crash risks, clear violations]
+
+| # | Finding | File:Line | Agents |
+|---|---------|-----------|--------|
+| 1 | [Description] | [file:line] | [which agents found it] |
+| 2 | [Description] | [file:line] | [which agents found it] |
+
+### Should Consider (CONSIDER) — M
 [Judgment calls — improvement likely but has trade-offs]
-- [agent(s)]: Issue description [file:line]
+
+| # | Finding | File:Line | Agents |
+|---|---------|-----------|--------|
+| N+1 | [Description] | [file:line] | [which agents found it] |
+| N+2 | [Description] | [file:line] | [which agents found it] |
 
 ### Tensions
 [Where agents disagree — present both sides and the trade-off]
 
-### Policy Decisions (POLICY)
+### Policy Decisions (POLICY) — P
 [Require team/project-level decisions, not local fixes]
-- [agent(s)]: Issue description
 
-### Acceptable / No Action (ACCEPTABLE)
-[Count only: N items classified as acceptable across all agents]
+| # | Finding | Agents |
+|---|---------|--------|
+| M+1 | [Description] | [which agents found it] |
+
+### Acceptable / No Action (ACCEPTABLE) — Q
+[Enumerate briefly — these are intentional deferrals, re-exports, etc.]
+
+| # | Finding | File:Line |
+|---|---------|-----------|
+| P+1 | [Description] | [file:line] |
 
 ## Strengths
 
@@ -224,17 +241,19 @@ Before writing the summary:
 
 ## Recommended Action Plan
 
+Reference findings by their global number from the tables above.
+
 ### Immediate (this week)
 [Prioritize items from the git-history-analyzer risk matrix — highest risk items first]
-1. [FIX item]
-2. [FIX item]
+1. [Fix Finding N — description]
+2. [Fix Finding M — description]
 
 ### Short-term (this month)
-1. [CONSIDER item]
-2. [CONSIDER item]
+1. [Finding N+1 — description]
+2. [Finding N+2 — description]
 
 ### Ongoing
-1. [POLICY decision to make]
+1. [Finding M+1 — policy decision to make]
 2. [Convention to establish]
 ```
 

--- a/plugins/code-review-toolkit/scripts/analyze_history.py
+++ b/plugins/code-review-toolkit/scripts/analyze_history.py
@@ -24,6 +24,7 @@ import sys
 import time
 from collections import defaultdict
 from collections.abc import Iterable
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -262,10 +263,14 @@ def compute_function_churn_level2(
     scan_root: Path,
     project_root: Path,
     max_files: int = 0,
+    workers: int = 8,
 ) -> list[dict]:
     """Level 2: Map diff hunks to function boundaries using AST.
 
     Analyzes already-parsed commits to map file changes to functions.
+    When ``workers`` is greater than 1, per-commit diff fetches are
+    parallelised via a :class:`ThreadPoolExecutor`; passing ``workers=1``
+    preserves the previous fully-serial behaviour.
     """
     # Build function boundaries for all Python files in scope.
     file_functions: dict[str, list[dict]] = {}
@@ -303,40 +308,64 @@ def compute_function_churn_level2(
     if not file_functions:
         return []
 
-    # For each commit, get the diff and map hunks to functions.
+    # Collect (commit_hash, file_path) work items for all commits touching
+    # files whose function boundaries we have parsed.
+    work_items: list[tuple[str, str]] = []
+    for commit in commits:
+        for file_path in commit["files"]:
+            if file_path in file_functions:
+                work_items.append((commit["hash"], file_path))
+
     func_commits: dict[tuple[str, str], set[str]] = defaultdict(set)
 
-    for commit in commits:
-        if _check_script_timeout():
-            break
-        for file_path in commit["files"]:
-            if file_path not in file_functions:
-                continue
-            try:
-                diff_result = _run_git(
-                    ["show", "--format=", "-U0", commit["hash"], "--", file_path],
-                    project_root,
-                )
-                if diff_result.returncode != 0:
-                    continue
-            except subprocess.TimeoutExpired:
-                continue
+    def _fetch_hunk(
+        item: tuple[str, str],
+    ) -> tuple[str, str, set[int]]:
+        """Fetch the changed line numbers for one (commit, file) pair."""
+        commit_hash, file_path = item
+        try:
+            diff_result = _run_git(
+                ["show", "--format=", "-U0", commit_hash, "--", file_path],
+                project_root,
+            )
+            if diff_result.returncode != 0:
+                return commit_hash, file_path, set()
+        except subprocess.TimeoutExpired:
+            return commit_hash, file_path, set()
 
-            # Parse diff hunks to find changed line ranges.
-            changed_lines: set[int] = set()
-            for line in diff_result.stdout.splitlines():
-                hunk_match = re.match(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", line)
-                if hunk_match:
-                    start = int(hunk_match.group(1))
-                    count = int(hunk_match.group(2)) if hunk_match.group(2) else 1
-                    changed_lines.update(range(start, start + count))
+        changed_lines: set[int] = set()
+        for diff_line in diff_result.stdout.splitlines():
+            hunk_match = re.match(
+                r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", diff_line,
+            )
+            if hunk_match:
+                start = int(hunk_match.group(1))
+                count = int(hunk_match.group(2)) if hunk_match.group(2) else 1
+                changed_lines.update(range(start, start + count))
+        return commit_hash, file_path, changed_lines
 
-            # Map changed lines to functions.
-            for func in file_functions[file_path]:
-                func_range = set(range(func["line_start"], func["line_end"] + 1))
-                if changed_lines & func_range:
-                    key = (file_path, func["name"])
-                    func_commits[key].add(commit["hash"])
+    def _record(commit_hash: str, file_path: str, changed_lines: set[int]) -> None:
+        if not changed_lines:
+            return
+        for func in file_functions[file_path]:
+            func_range = set(range(func["line_start"], func["line_end"] + 1))
+            if changed_lines & func_range:
+                func_commits[(file_path, func["name"])].add(commit_hash)
+
+    if workers <= 1:
+        # Serial path (preserves prior behaviour exactly).
+        for item in work_items:
+            if _check_script_timeout():
+                break
+            _record(*_fetch_hunk(item))
+    else:
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            for commit_hash, file_path, changed_lines in pool.map(
+                _fetch_hunk, work_items,
+            ):
+                if _check_script_timeout():
+                    break
+                _record(commit_hash, file_path, changed_lines)
 
     # Build result.
     results: list[dict] = []
@@ -369,79 +398,129 @@ def _truncate_diff(diff_text: str, max_lines: int) -> str:
     return truncated + "\n[diff truncated, full diff available via git show HASH]"
 
 
+def _collect_commit_detail(
+    commit: dict,
+    project_root: Path,
+    rel_scope: str,
+    max_diff_lines: int,
+) -> dict:
+    """Fetch diff and function-modification info for one commit.
+
+    Extracted as a free function so it can be submitted to a thread pool
+    by :func:`get_commit_details`.
+    """
+    diff_args = ["show", "--format=", "--patch", commit["hash"], "--"]
+    if rel_scope != ".":
+        diff_args.append(rel_scope)
+    try:
+        diff_result = _run_git(diff_args, project_root)
+        diff_text = diff_result.stdout if diff_result.returncode == 0 else ""
+    except subprocess.TimeoutExpired:
+        diff_text = "[diff unavailable: git show timed out]"
+
+    diff_text = _truncate_diff(diff_text, max_diff_lines)
+
+    # Map to functions if possible.
+    functions_modified: list[dict] = []
+    for file_path in commit["files"]:
+        full_path = project_root / file_path
+        if full_path.suffix == ".py" and full_path.exists():
+            boundaries = get_function_boundaries(full_path)
+            try:
+                func_diff = _run_git(
+                    ["show", "--format=", "-U0", commit["hash"], "--", file_path],
+                    project_root,
+                )
+                if func_diff.returncode == 0:
+                    changed_lines: set[int] = set()
+                    for line in func_diff.stdout.splitlines():
+                        hunk = re.match(
+                            r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", line
+                        )
+                        if hunk:
+                            start = int(hunk.group(1))
+                            count = int(hunk.group(2)) if hunk.group(2) else 1
+                            changed_lines.update(range(start, start + count))
+                    for func in boundaries:
+                        func_range = set(
+                            range(func["line_start"], func["line_end"] + 1)
+                        )
+                        if changed_lines & func_range:
+                            functions_modified.append({
+                                "function": func["name"],
+                                "file": file_path,
+                            })
+            except subprocess.TimeoutExpired:
+                pass
+
+    return {
+        "commit": commit["hash"],
+        "commit_short": commit["hash"][:7],
+        "message": commit["message"],
+        "date": commit["date"],
+        "author": commit["author"],
+        "files": commit["files"],
+        "functions_modified": functions_modified,
+        "diff": diff_text,
+    }
+
+
 def get_commit_details(
     commits: list[dict],
     commit_type: str,
     project_root: Path,
     scan_root: Path,
     max_diff_lines: int,
+    workers: int = 8,
 ) -> list[dict]:
-    """Get detailed info for commits of a specific type."""
+    """Get detailed info for commits of a specific type.
+
+    When ``workers`` is greater than 1, per-commit ``git show`` calls are
+    parallelised via a :class:`ThreadPoolExecutor`; ``workers=1`` preserves
+    the previous fully-serial behaviour.
+    """
     typed_commits = [c for c in commits if c["type"] == commit_type]
-    results: list[dict] = []
+    if not typed_commits:
+        return []
 
     rel_scope = _relative_scope(scan_root, project_root)
+    results: list[dict] = []
+
+    if workers <= 1:
+        for commit in typed_commits:
+            if _check_script_timeout():
+                break
+            results.append(
+                _collect_commit_detail(
+                    commit, project_root, rel_scope, max_diff_lines,
+                )
+            )
+        return results
+
+    # Parallel path — preserve original commit order on output.
+    detail_map: dict[str, dict] = {}
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {
+            pool.submit(
+                _collect_commit_detail,
+                commit, project_root, rel_scope, max_diff_lines,
+            ): commit["hash"]
+            for commit in typed_commits
+        }
+        for future in as_completed(futures):
+            if _check_script_timeout():
+                pool.shutdown(wait=False, cancel_futures=True)
+                break
+            try:
+                detail = future.result()
+            except Exception:  # noqa: BLE001 -- best-effort per-commit
+                continue
+            detail_map[detail["commit"]] = detail
 
     for commit in typed_commits:
-        if _check_script_timeout():
-            break
-        # Get the diff.
-        diff_args = ["show", "--format=", "--patch", commit["hash"], "--"]
-        if rel_scope != ".":
-            diff_args.append(rel_scope)
-        try:
-            diff_result = _run_git(diff_args, project_root)
-            diff_text = diff_result.stdout if diff_result.returncode == 0 else ""
-        except subprocess.TimeoutExpired:
-            diff_text = "[diff unavailable: git show timed out]"
-
-        diff_text = _truncate_diff(diff_text, max_diff_lines)
-
-        # Map to functions if possible.
-        functions_modified: list[dict] = []
-        for file_path in commit["files"]:
-            full_path = project_root / file_path
-            if full_path.suffix == ".py" and full_path.exists():
-                boundaries = get_function_boundaries(full_path)
-                # Parse the diff to find which functions were modified.
-                try:
-                    func_diff = _run_git(
-                        ["show", "--format=", "-U0", commit["hash"], "--", file_path],
-                        project_root,
-                    )
-                    if func_diff.returncode == 0:
-                        changed_lines: set[int] = set()
-                        for line in func_diff.stdout.splitlines():
-                            hunk = re.match(
-                                r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", line
-                            )
-                            if hunk:
-                                start = int(hunk.group(1))
-                                count = int(hunk.group(2)) if hunk.group(2) else 1
-                                changed_lines.update(range(start, start + count))
-                        for func in boundaries:
-                            func_range = set(
-                                range(func["line_start"], func["line_end"] + 1)
-                            )
-                            if changed_lines & func_range:
-                                functions_modified.append({
-                                    "function": func["name"],
-                                    "file": file_path,
-                                })
-                except subprocess.TimeoutExpired:
-                    pass
-
-        results.append({
-            "commit": commit["hash"],
-            "commit_short": commit["hash"][:7],
-            "message": commit["message"],
-            "date": commit["date"],
-            "author": commit["author"],
-            "files": commit["files"],
-            "functions_modified": functions_modified,
-            "diff": diff_text,
-        })
-
+        detail = detail_map.get(commit["hash"])
+        if detail is not None:
+            results.append(detail)
     return results
 
 
@@ -491,6 +570,7 @@ def parse_args(argv: list[str]) -> dict:
         "last": None,
         "max_commits": 2000,
         "max_files": 0,
+        "workers": 8,
         "no_function": False,
     }
 
@@ -536,6 +616,16 @@ def parse_args(argv: list[str]) -> dict:
                 print(
                     f"Error: --max-files requires an integer, "
                     f"got '{argv[i + 1]}'",
+                    file=sys.stderr,
+                )
+                sys.exit(2)
+            i += 2
+        elif arg == "--workers" and i + 1 < len(argv):
+            try:
+                args["workers"] = int(argv[i + 1])
+            except ValueError:
+                print(
+                    f"Error: --workers requires an integer, got '{argv[i + 1]}'",
                     file=sys.stderr,
                 )
                 sys.exit(2)
@@ -593,10 +683,20 @@ def analyze(argv: list[str] | None = None) -> dict:
         git_args.append(rel_scope)
 
     proc = _run_git_streaming(git_args, project_root)
-    commits, file_churn = parse_git_log(
-        proc.stdout, max_commits, project_root,
-    )
-    proc.wait()
+    try:
+        commits, file_churn = parse_git_log(
+            proc.stdout, max_commits, project_root,
+        )
+    finally:
+        # Terminate git if it's still writing: parse_git_log may have
+        # stopped reading (e.g. max_commits reached) before git finished,
+        # and an un-drained pipe can dead-lock the child.
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
 
     # If using --last, derive time range from actual commits.
     commit_cap_applied = len(commits) >= max_commits
@@ -620,6 +720,8 @@ def analyze(argv: list[str] | None = None) -> dict:
         commits_by_type[commit["type"]] += 1
         authors.add(commit["author"])
 
+    workers = args["workers"]
+
     # Function-level churn.
     function_churn: list[dict] = []
     function_churn_note: str | None = None
@@ -632,6 +734,7 @@ def analyze(argv: list[str] | None = None) -> dict:
         function_churn = compute_function_churn_level2(
             commits, scan_root, project_root,
             max_files=args["max_files"],
+            workers=workers,
         )
         if _check_script_timeout():
             function_churn_note = (
@@ -640,13 +743,16 @@ def analyze(argv: list[str] | None = None) -> dict:
 
     # Get recent fixes, features, refactors.
     recent_fixes = get_commit_details(
-        commits, "fix", project_root, scan_root, _MAX_DIFF_LINES_FIX
+        commits, "fix", project_root, scan_root, _MAX_DIFF_LINES_FIX,
+        workers=workers,
     )
     recent_features = get_commit_details(
-        commits, "feature", project_root, scan_root, _MAX_DIFF_LINES_FIX
+        commits, "feature", project_root, scan_root, _MAX_DIFF_LINES_FIX,
+        workers=workers,
     )
     recent_refactors = get_commit_details(
-        commits, "refactor", project_root, scan_root, _MAX_DIFF_LINES_REFACTOR
+        commits, "refactor", project_root, scan_root,
+        _MAX_DIFF_LINES_REFACTOR, workers=workers,
     )
 
     # Co-change clusters.

--- a/plugins/code-review-toolkit/scripts/collect_debt.py
+++ b/plugins/code-review-toolkit/scripts/collect_debt.py
@@ -9,12 +9,21 @@ Usage:
 """
 
 import json
+import os
 import re
 import subprocess
 import sys
 from collections.abc import Generator
 from datetime import datetime, timezone
 from pathlib import Path
+
+# Allow importing the sibling scan_common module when this script is
+# invoked directly (not via the test helpers).
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+
+from scan_common import extract_nearby_comments, has_safety_annotation  # noqa: E402
 
 
 # Patterns to search for, grouped by category.
@@ -126,7 +135,8 @@ def scan_file(
 ) -> list[dict]:
     """Scan a file for debt markers."""
     try:
-        lines = filepath.read_text(encoding="utf-8", errors="replace").splitlines()
+        source = filepath.read_text(encoding="utf-8", errors="replace")
+        lines = source.splitlines()
     except OSError:
         return []
 
@@ -144,6 +154,25 @@ def scan_file(
                 context_before = lines[i - 2].strip() if i > 1 else ""
                 context_after = lines[i].strip() if i < len(lines) else ""
 
+                # Comment-aware triage: inspect nearby comments for
+                # safety annotations. A noqa suppresses the item entirely;
+                # other safety annotations downgrade confidence.
+                nearby_comments = extract_nearby_comments(source, i)
+                # Exclude the marker line itself so the NOQA/TODO keyword
+                # in `text` doesn't trivially match itself.
+                other_comments = [
+                    c for c in nearby_comments
+                    if c.strip() != line.strip().lstrip("#").strip()
+                ]
+                confidence = "high"
+                if category != "NOQA" and any(
+                    "noqa" in c.lower() for c in other_comments
+                ):
+                    # A sibling noqa on an adjacent line suppresses this item.
+                    continue
+                if has_safety_annotation(other_comments):
+                    confidence = "low"
+
                 item: dict = {
                     "file": rel,
                     "line": i,
@@ -152,6 +181,7 @@ def scan_file(
                     "full_line": line.rstrip(),
                     "context_before": context_before,
                     "context_after": context_after,
+                    "confidence": confidence,
                 }
 
                 if use_git:
@@ -169,6 +199,14 @@ def scan_file(
 
         # Check skip decorators.
         if _SKIP_PATTERN.search(line):
+            # Comment-aware triage for skip decorators too.
+            nearby_comments = extract_nearby_comments(source, i)
+            confidence = "high"
+            if any("noqa" in c.lower() for c in nearby_comments):
+                continue
+            if has_safety_annotation(nearby_comments):
+                confidence = "low"
+
             item = {
                 "file": rel,
                 "line": i,
@@ -178,6 +216,7 @@ def scan_file(
                 "context_before": lines[i - 2].strip() if i > 1 else "",
                 "context_after": lines[i].strip() if i < len(lines) else "",
                 "age": "unknown",
+                "confidence": confidence,
             }
             if use_git:
                 blame = _git_blame_line(filepath, i, project_root)

--- a/plugins/code-review-toolkit/scripts/find_dead_symbols.py
+++ b/plugins/code-review-toolkit/scripts/find_dead_symbols.py
@@ -11,10 +11,19 @@ Usage:
 
 import ast
 import json
+import os
 import re
 import sys
 from collections.abc import Generator
 from pathlib import Path
+
+# Allow importing the sibling scan_common module when this script is
+# invoked directly (not via the test helpers).
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+
+from scan_common import extract_nearby_comments, has_safety_annotation  # noqa: E402
 
 
 def discover_python_files(root: Path) -> Generator[Path, None, None]:
@@ -100,6 +109,9 @@ def analyze_file(filepath: Path, project_root: Path) -> dict:
     except SyntaxError as exc:
         result["parse_error"] = f"SyntaxError: {exc.msg} (line {exc.lineno})"
         return result
+
+    # Retain source for comment-aware triage (dropped in main() to save memory).
+    result["source"] = source
 
     # Check for __all__.
     for node in ast.walk(tree):
@@ -206,6 +218,7 @@ def find_unused_imports(file_analysis: dict) -> list[dict]:
     unused = []
     refs = file_analysis["referenced_names"]
     all_decl = file_analysis["all_declaration"]
+    source = file_analysis.get("source", "")
 
     for imp in file_analysis["imports"]:
         local_name = imp["local_name"]
@@ -219,12 +232,23 @@ def find_unused_imports(file_analysis: dict) -> list[dict]:
         if file_analysis["is_init"]:
             continue
 
+        # Comment-aware triage: check for safety annotations near the line.
+        confidence = "high"
+        nearby_comments: list[str] = []
+        if source:
+            nearby_comments = extract_nearby_comments(source, imp["line"])
+            if any("noqa" in c.lower() for c in nearby_comments):
+                # Skip entirely — explicit lint suppression.
+                continue
+            if has_safety_annotation(nearby_comments):
+                confidence = "low"
+
         unused.append({
             "file": file_analysis["file"],
             "line": imp["line"],
             "name": local_name,
             "module": imp["module"],
-            "confidence": "high",
+            "confidence": confidence,
         })
 
     return unused
@@ -286,6 +310,16 @@ def find_unreferenced_symbols(
                 # dynamically dispatched.
                 if sym["type"] == "class" and sym["is_public"]:
                     confidence = "medium"  # Classes may be instantiated dynamically.
+
+                # Comment-aware triage: suppress or downgrade if a nearby
+                # safety annotation indicates the symbol is intentionally kept.
+                source = fa.get("source", "")
+                if source:
+                    nearby_comments = extract_nearby_comments(source, sym["line"])
+                    if any("noqa" in c.lower() for c in nearby_comments):
+                        continue
+                    if has_safety_annotation(nearby_comments):
+                        confidence = "low"
 
                 unreferenced.append({
                     "file": fa["file"],
@@ -430,9 +464,10 @@ def main() -> None:
 
     unreferenced = find_unreferenced_symbols(file_analyses)
 
-    # Drop per-file referenced_names to free memory.
+    # Drop per-file referenced_names and source to free memory.
     for fa in file_analyses:
         fa.pop("referenced_names", None)
+        fa.pop("source", None)
 
     orphans = find_orphan_files(file_analyses, project_root)
 

--- a/plugins/code-review-toolkit/scripts/scan_common.py
+++ b/plugins/code-review-toolkit/scripts/scan_common.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Shared utilities for code-review-toolkit analysis scripts."""
+from __future__ import annotations
+
+import ast
+from typing import Iterable
+
+
+_SAFETY_KEYWORDS = frozenset({
+    "safety:", "safe because", "intentional", "by design", "nolint",
+    "checked:", "correct because", "this is safe", "not a bug",
+    "deliberately", "expected", "noqa",
+})
+
+
+def extract_nearby_comments(source: str, line: int, radius: int = 5) -> list[str]:
+    """Extract `#` comments within +/- radius of the 1-based line number.
+
+    Pure-source scan (no AST): Python comments aren't in the AST, so we
+    tokenize. Returns stripped comment text (without the `#`).
+    """
+    import tokenize, io
+    comments: list[str] = []
+    min_line = max(1, line - radius)
+    max_line = line + radius
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+            if tok.type == tokenize.COMMENT and min_line <= tok.start[0] <= max_line:
+                text = tok.string.lstrip("#").strip()
+                comments.append(text)
+    except (tokenize.TokenizeError, IndentationError):
+        # Fall back to line-based scan on broken input.
+        lines = source.splitlines()
+        for i in range(min_line - 1, min(max_line, len(lines))):
+            stripped = lines[i].lstrip()
+            if stripped.startswith("#"):
+                comments.append(stripped[1:].strip())
+    return comments
+
+
+def has_safety_annotation(comments: Iterable[str]) -> bool:
+    """Return True if any comment contains a safety-annotation keyword."""
+    for comment in comments:
+        lower = comment.lower()
+        if any(kw in lower for kw in _SAFETY_KEYWORDS):
+            return True
+    return False
+
+
+def make_finding(
+    finding_type: str,
+    *,
+    file: str = "",
+    line: int = 0,
+    function: str = "",
+    classification: str,
+    severity: str,
+    confidence: str = "high",
+    detail: str,
+    **extra,
+) -> dict:
+    """Create a finding dict with consistent key naming."""
+    finding: dict = {
+        "type": finding_type,
+        "file": file,
+        "line": line,
+        "function": function,
+        "classification": classification,
+        "severity": severity,
+        "confidence": confidence,
+        "detail": detail,
+    }
+    finding.update(extra)
+    return finding

--- a/tests/test_analyze_history.py
+++ b/tests/test_analyze_history.py
@@ -527,5 +527,61 @@ class TestMaxFilesArg(unittest.TestCase):
         self.assertEqual(args["max_files"], 50)
 
 
+class TestWorkersArg(unittest.TestCase):
+    """Test --workers argument parsing for ThreadPoolExecutor tuning."""
+
+    def test_workers_default(self):
+        args = mod.parse_args([])
+        self.assertEqual(args["workers"], 8)
+
+    def test_workers_set(self):
+        args = mod.parse_args(["--workers", "4"])
+        self.assertEqual(args["workers"], 4)
+
+    def test_workers_with_path_and_other_flags(self):
+        args = mod.parse_args(["src/", "--workers", "2", "--no-function"])
+        self.assertEqual(args["workers"], 2)
+        self.assertEqual(args["path"], "src/")
+        self.assertTrue(args["no_function"])
+
+
+class TestAnalyzeSmokeNoHang(unittest.TestCase):
+    """Smoke test that ``analyze`` returns quickly without hanging on the pipe."""
+
+    def test_analyze_small_repo_terminates(self):
+        # One tiny commit — the pipe-deadlock fix should guarantee this
+        # returns promptly even when we cap commits.
+        import signal
+
+        with GitTempProject([
+            {
+                "files": {"a.py": "x = 1\n"},
+                "message": "Add a",
+                "date": "2025-01-01T12:00:00+00:00",
+            },
+        ]) as root:
+            # Defensive alarm: if analyze hangs, fail loudly instead of
+            # hanging the whole test suite.
+            if hasattr(signal, "SIGALRM"):
+                def _timeout(signum, frame):
+                    raise AssertionError("analyze() hung — pipe deadlock?")
+                old = signal.signal(signal.SIGALRM, _timeout)
+                signal.alarm(30)
+            try:
+                result = mod.analyze([
+                    str(root),
+                    "--since", "2024-12-01",
+                    "--until", "2025-02-01",
+                    "--max-commits", "1",
+                    "--workers", "2",
+                ])
+            finally:
+                if hasattr(signal, "SIGALRM"):
+                    signal.alarm(0)
+                    signal.signal(signal.SIGALRM, old)
+            self.assertNotIn("error", result)
+            self.assertEqual(result["summary"]["total_commits"], 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_collect_debt.py
+++ b/tests/test_collect_debt.py
@@ -213,5 +213,38 @@ class TestMaxFiles(unittest.TestCase):
             self.assertGreater(output["files_total"], 3)
 
 
+class TestAnnotationAwareTriage(unittest.TestCase):
+    """Tests for comment-aware triage of debt markers."""
+
+    def _scan(self, source: str, filename: str = "mod.py") -> list[dict]:
+        with TempProject({filename: source}) as root:
+            return mod.scan_file(root / filename, root, use_git=False)
+
+    def test_safety_comment_downgrades_confidence(self):
+        # A SAFETY comment adjacent to a FIXME should downgrade confidence.
+        items = self._scan(
+            "# SAFETY: reviewed — left intentional\n"
+            "x = 1  # FIXME: tighten later\n"
+        )
+        fixmes = [i for i in items if i["category"] == "FIXME"]
+        self.assertEqual(len(fixmes), 1)
+        self.assertEqual(fixmes[0]["confidence"], "low")
+
+    def test_no_annotation_keeps_confidence_high(self):
+        items = self._scan("x = 1  # FIXME: tighten later\n")
+        fixmes = [i for i in items if i["category"] == "FIXME"]
+        self.assertEqual(len(fixmes), 1)
+        self.assertEqual(fixmes[0]["confidence"], "high")
+
+    def test_sibling_noqa_suppresses_todo(self):
+        # A sibling noqa comment should suppress the TODO entirely.
+        items = self._scan(
+            "# noqa: review approved\n"
+            "x = 1  # TODO: revisit\n"
+        )
+        todos = [i for i in items if i["category"] == "TODO"]
+        self.assertEqual(len(todos), 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_find_dead_symbols.py
+++ b/tests/test_find_dead_symbols.py
@@ -82,6 +82,27 @@ class TestUnusedImports(unittest.TestCase):
         self.assertEqual(len(unused), 1)
         self.assertEqual(unused[0]["name"], "np")
 
+    def test_noqa_suppresses_unused_import(self):
+        """An adjacent ``# noqa`` should suppress the finding entirely."""
+        unused = self._find_unused(
+            "# noqa: F401\n"
+            "import json\n"
+            "\n"
+            "x = 1\n"
+        )
+        self.assertEqual(len(unused), 0)
+
+    def test_safety_comment_downgrades_confidence(self):
+        """A ``# SAFETY: ...`` comment downgrades confidence to low."""
+        unused = self._find_unused(
+            "# SAFETY: reviewed — imported for side effects\n"
+            "import json\n"
+            "\n"
+            "x = 1\n"
+        )
+        self.assertEqual(len(unused), 1)
+        self.assertEqual(unused[0]["confidence"], "low")
+
 
 class TestUnreferencedSymbols(unittest.TestCase):
     """Test detection of defined-but-never-referenced symbols."""

--- a/tests/test_scan_common.py
+++ b/tests/test_scan_common.py
@@ -1,0 +1,183 @@
+"""Tests for scan_common.py — shared triage/annotation helpers."""
+
+import unittest
+
+from helpers import import_script
+
+mod = import_script("scan_common")
+
+
+class TestExtractNearbyComments(unittest.TestCase):
+    """Tests for extract_nearby_comments."""
+
+    def test_finds_comment_on_same_line(self):
+        source = "x = 1  # inline comment\n"
+        comments = mod.extract_nearby_comments(source, 1, radius=0)
+        self.assertIn("inline comment", comments)
+
+    def test_finds_comments_in_window(self):
+        source = (
+            "# before\n"        # line 1
+            "x = 1\n"           # line 2
+            "# after\n"         # line 3
+            "y = 2\n"           # line 4
+            "# far below\n"     # line 5
+        )
+        comments = mod.extract_nearby_comments(source, 2, radius=1)
+        self.assertIn("before", comments)
+        self.assertIn("after", comments)
+        # "far below" is 3 lines away, outside radius=1.
+        self.assertNotIn("far below", comments)
+
+    def test_ignores_out_of_range(self):
+        source = (
+            "# top\n"              # line 1
+            "x = 1\n"              # line 2
+            "y = 2\n"              # line 3
+            "z = 3\n"              # line 4
+            "# way down\n"         # line 5
+        )
+        # Scan around line 1 with small radius -- "way down" must NOT appear.
+        comments = mod.extract_nearby_comments(source, 1, radius=2)
+        self.assertIn("top", comments)
+        self.assertNotIn("way down", comments)
+
+    def test_strips_hash_and_whitespace(self):
+        source = "#   SAFETY: reviewed\nx = 1\n"
+        comments = mod.extract_nearby_comments(source, 1, radius=0)
+        self.assertEqual(comments, ["SAFETY: reviewed"])
+
+    def test_empty_source(self):
+        self.assertEqual(mod.extract_nearby_comments("", 1), [])
+
+    def test_broken_source_falls_back_to_line_scan(self):
+        # Unterminated string -> tokenize will raise; fallback should still
+        # find line-based comments.
+        source = (
+            "# safety: reviewed\n"
+            "x = 'unterminated\n"
+        )
+        comments = mod.extract_nearby_comments(source, 1, radius=0)
+        # Fallback path should still surface the leading comment.
+        self.assertTrue(
+            any("safety" in c.lower() for c in comments),
+            f"expected a safety comment, got {comments!r}",
+        )
+
+    def test_line_zero_clamped(self):
+        source = "# top\nx = 1\n"
+        comments = mod.extract_nearby_comments(source, 0, radius=2)
+        self.assertIn("top", comments)
+
+
+class TestHasSafetyAnnotation(unittest.TestCase):
+    """Tests for has_safety_annotation."""
+
+    def test_true_for_safety_colon(self):
+        self.assertTrue(mod.has_safety_annotation(["SAFETY: reviewed by ada"]))
+
+    def test_true_case_insensitive(self):
+        self.assertTrue(mod.has_safety_annotation(["safety: ok"]))
+        self.assertTrue(mod.has_safety_annotation(["SAFE BECAUSE x"]))
+
+    def test_true_for_nolint(self):
+        self.assertTrue(mod.has_safety_annotation(["nolint"]))
+
+    def test_true_for_noqa(self):
+        self.assertTrue(mod.has_safety_annotation(["noqa"]))
+        self.assertTrue(mod.has_safety_annotation(["noqa: F401"]))
+
+    def test_true_for_by_design(self):
+        self.assertTrue(mod.has_safety_annotation(["this is by design"]))
+
+    def test_true_for_intentional(self):
+        self.assertTrue(mod.has_safety_annotation(["intentional"]))
+
+    def test_true_for_deliberately(self):
+        self.assertTrue(
+            mod.has_safety_annotation(["deliberately unhandled"]),
+        )
+
+    def test_false_for_random_comment(self):
+        self.assertFalse(mod.has_safety_annotation(["random comment"]))
+
+    def test_false_for_empty(self):
+        self.assertFalse(mod.has_safety_annotation([]))
+        self.assertFalse(mod.has_safety_annotation([""]))
+
+    def test_false_for_unrelated(self):
+        self.assertFalse(
+            mod.has_safety_annotation(["TODO: refactor later", "cleanup"]),
+        )
+
+    def test_any_of_many_matches(self):
+        self.assertTrue(
+            mod.has_safety_annotation(
+                ["first", "second", "checked: by review"],
+            ),
+        )
+
+
+class TestMakeFinding(unittest.TestCase):
+    """Tests for make_finding."""
+
+    def test_consistent_keys(self):
+        f = mod.make_finding(
+            "unused-import",
+            file="foo.py",
+            line=10,
+            function="bar",
+            classification="FIX",
+            severity="high",
+            detail="imported but not used",
+        )
+        # Required keys all present.
+        expected = {
+            "type", "file", "line", "function", "classification",
+            "severity", "confidence", "detail",
+        }
+        self.assertTrue(expected.issubset(f.keys()))
+        self.assertEqual(f["type"], "unused-import")
+        self.assertEqual(f["file"], "foo.py")
+        self.assertEqual(f["line"], 10)
+        self.assertEqual(f["classification"], "FIX")
+        self.assertEqual(f["severity"], "high")
+        # Default confidence.
+        self.assertEqual(f["confidence"], "high")
+
+    def test_defaults(self):
+        f = mod.make_finding(
+            "debt",
+            classification="CONSIDER",
+            severity="low",
+            detail="foo",
+        )
+        self.assertEqual(f["file"], "")
+        self.assertEqual(f["line"], 0)
+        self.assertEqual(f["function"], "")
+
+    def test_extra_fields_merged(self):
+        f = mod.make_finding(
+            "dead-code",
+            classification="FIX",
+            severity="medium",
+            detail="unreferenced",
+            module="pkg.foo",
+            name="helper",
+        )
+        self.assertEqual(f["module"], "pkg.foo")
+        self.assertEqual(f["name"], "helper")
+
+    def test_custom_confidence(self):
+        f = mod.make_finding(
+            "x",
+            classification="CONSIDER",
+            severity="low",
+            detail="d",
+            confidence="low",
+        )
+        self.assertEqual(f["confidence"], "low")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR ports four high-value cross-cutting improvements from the sibling `-review-toolkit` plugins:

- **Global non-restarting finding numbering** in `commands/explore.md` — the Phase 3 synthesis now numbers findings sequentially across FIX, CONSIDER, POLICY, and ACCEPTABLE sections (1..Q) so the Recommended Action Plan can reference the same global numbers. This makes it easy to cite "Finding 37" across issue trackers, emails, and code review threads. Synthesis tables updated verbatim from `cext-review-toolkit`'s rubric.
- **Comment-aware triage** — new `scripts/scan_common.py` exposes `extract_nearby_comments`, `has_safety_annotation`, and `make_finding` helpers, adapted for Python source (tokenize-based, with line-scan fallback). `find_dead_symbols.py` and `collect_debt.py` now consult these helpers before emitting each finding: a nearby `# noqa` suppresses the item entirely, and other safety annotations (e.g. `SAFETY:`, `by design`, `intentional`, `nolint`, `checked:`) downgrade confidence to `low`. The annotation vocabulary is documented in new `## Annotations` sections on the `dead-code-finder` and `tech-debt-inventory` agent prompts.
- **ThreadPoolExecutor parallelization** in `scripts/analyze_history.py` — `compute_function_churn_level2` and `get_commit_details` now fan out `git show` subprocesses across a thread pool (default 8 workers, tunable with `--workers N`, serial when `workers==1`). Large histories no longer serialise on diff fetches.
- **Pipe-deadlock fix** in `scripts/analyze_history.py` — `parse_git_log(proc.stdout, ...)` is now wrapped in `try/finally` that calls `proc.terminate()` before `proc.wait(timeout=5)` (with a `kill` fallback). This prevents a deadlock when `parse_git_log` stops reading early (e.g. after hitting `max_commits`) while `git log` is still writing into the unbuffered pipe.

## Ports from

- **cpython-review-toolkit**: `ThreadPoolExecutor` pattern for `compute_function_churn`/`get_commit_details` and the `proc.terminate()` pipe-deadlock fix (see `plugins/cpython-review-toolkit/scripts/analyze_history.py`).
- **cext-review-toolkit**: Global non-restarting numbering rubric and table templates for the Phase 3 synthesis (see `plugins/cext-review-toolkit/commands/explore.md`).
- **ft-review-toolkit**: Comment-aware triage helpers (adapted here for Python via `tokenize` rather than tree-sitter).

## Test plan

- [x] `python -m unittest discover tests` — 324 tests pass (up from 293; +31 new tests)
- [x] New `tests/test_scan_common.py` covers `extract_nearby_comments` window behaviour, `has_safety_annotation` keyword coverage, and `make_finding` key consistency
- [x] `tests/test_analyze_history.py` extended with `TestWorkersArg` (`--workers` default 8, settable, composes with other flags) and `TestAnalyzeSmokeNoHang` (asserts `analyze()` of a small repo returns under a 30s signal-based alarm, guarding against pipe regression)
- [x] `tests/test_find_dead_symbols.py` extended with `test_noqa_suppresses_unused_import` and `test_safety_comment_downgrades_confidence`
- [x] `tests/test_collect_debt.py` extended with `TestAnnotationAwareTriage` (SAFETY downgrades confidence, sibling noqa suppresses TODO, no-annotation stays high)
- [ ] Smoke test: run `/code-review-toolkit:explore` end-to-end on a project to confirm the new global-numbering tables render cleanly

https://claude.ai/code/session_01ByAMu9bhKyuV3SXb3dx4xF