### PR TITLE
Fix analyze_history crash on non-UTF-8 git output; surface ignored flags and commit cap

### DIFF
--- a/plugins/code-review-toolkit/scripts/analyze_history.py
+++ b/plugins/code-review-toolkit/scripts/analyze_history.py
@@ -81,10 +81,16 @@ def _run_git(
     timeout: int = _GIT_TIMEOUT,
 ) -> subprocess.CompletedProcess[str]:
     """Run a git command with timeout handling."""
+    # errors="replace": commit messages and diffs are not guaranteed UTF-8.
+    # Under the default strict decoding a single pre-UTF-8 commit anywhere in
+    # the window raises UnicodeDecodeError and takes down the entire analysis
+    # (observed on CPython: one 2015 commit killed a 9,203-commit run). A
+    # mangled character in one old subject line is the better trade.
     return subprocess.run(
         ["git"] + args,
         capture_output=True,
         text=True,
+        errors="replace",
         cwd=str(cwd),
         timeout=timeout,
     )
@@ -94,11 +100,13 @@ def _run_git_streaming(
     args: list[str], cwd: Path,
 ) -> subprocess.Popen[str]:
     """Run a git command with streaming stdout."""
+    # See _run_git: a non-UTF-8 commit message must not kill the stream.
     return subprocess.Popen(
         ["git"] + args,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        errors="replace",
         cwd=str(cwd),
     )
 
@@ -492,6 +500,7 @@ def parse_args(argv: list[str]) -> dict:
         "max_commits": 2000,
         "max_files": 0,
         "no_function": False,
+        "unknown_args": [],
     }
 
     i = 0
@@ -547,7 +556,12 @@ def parse_args(argv: list[str]) -> dict:
             args["path"] = arg
             i += 1
         else:
+            # A stderr warning alone is easy to lose in an agent transcript, so
+            # also carry the flag into the JSON envelope: a silently-ignored
+            # window flag otherwise yields a confident, wrong analysis at the
+            # default window.
             print(f"Warning: unknown flag '{arg}', ignoring", file=sys.stderr)
+            args["unknown_args"].append(arg)
             i += 1
 
     return args
@@ -675,10 +689,33 @@ def analyze(argv: list[str] | None = None) -> dict:
         "recent_features": recent_features,
         "recent_refactors": recent_refactors,
         "co_change_clusters": co_change_clusters,
+        "notes": [],
     }
 
     if function_churn_note:
         result["function_churn_note"] = function_churn_note
+        result["notes"].append(
+            "Function-level churn was skipped -- `function_churn` is empty by "
+            "request, not because nothing changed."
+        )
+
+    if args["unknown_args"]:
+        result["unknown_args"] = args["unknown_args"]
+        result["notes"].append(
+            "Unrecognized argument(s) IGNORED: "
+            + ", ".join(args["unknown_args"])
+            + ". The analysis below ran with default values for whatever those "
+            "flags were meant to set -- re-run with the correct flag before "
+            "trusting any temporal claim."
+        )
+
+    if commit_cap_applied:
+        result["notes"].append(
+            f"COMMIT CAP APPLIED: analysis stopped at --max-commits "
+            f"{max_commits}; the window contains at least that many commits, "
+            "so everything below is a truncated prefix of the real history. "
+            "Raise --max-commits or narrow the window."
+        )
 
     return result
 

--- a/tests/test_analyze_history.py
+++ b/tests/test_analyze_history.py
@@ -527,5 +527,100 @@ class TestMaxFilesArg(unittest.TestCase):
         self.assertEqual(args["max_files"], 50)
 
 
+def _latin1_repo(testcase) -> Path:
+    """A one-commit git repo whose diff payload is not valid UTF-8."""
+    import shutil
+    import tempfile
+
+    tmpdir = tempfile.mkdtemp(prefix="crt_latin1_")
+    testcase.addCleanup(shutil.rmtree, tmpdir, True)
+    root = Path(tmpdir)
+    # git never transcodes diff payload, so latin-1 bytes in file *content* are
+    # what actually reach the decoder.
+    (root / "mod.py").write_bytes(
+        b"# Alejandro L\xf3pez-Ortiz\ndef f():\n    return 1\n"
+    )
+    for args in (
+        ["init", "-q"],
+        ["config", "user.name", "Test Author"],
+        ["config", "user.email", "test@example.invalid"],
+        ["config", "commit.gpgsign", "false"],
+        ["add", "-A"],
+        ["commit", "-q", "-m", "gh-1: Fix segfault in listsort"],
+    ):
+        subprocess.run(
+            ["git", *args], cwd=tmpdir, check=True,
+            capture_output=True, text=True, errors="replace",
+        )
+    return root
+
+
+class TestNonUtf8History(unittest.TestCase):
+    """A non-UTF-8 byte anywhere in a diff must not abort the analysis.
+
+    Both git subprocess sites pass errors="replace". Without it, one pre-UTF-8
+    commit raises UnicodeDecodeError and takes down the whole run — observed on
+    CPython, where a single 2015 commit killed a 9,203-commit analysis.
+    """
+
+    def test_strict_decoding_would_have_failed(self):
+        # Guard the guard: if this stops raising, the fixture no longer
+        # exercises the bug and the tests below prove nothing.
+        root = _latin1_repo(self)
+        with self.assertRaises(UnicodeDecodeError):
+            subprocess.run(
+                ["git", "show", "--format=", "--patch", "HEAD"],
+                cwd=str(root), capture_output=True, text=True, check=False,
+            )
+
+    def test_run_git_survives_non_utf8_diff(self):
+        root = _latin1_repo(self)
+        result = mod._run_git(["show", "--format=", "--patch", "HEAD"], root)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("Alejandro", result.stdout)
+
+    def test_run_git_streaming_survives_non_utf8_diff(self):
+        root = _latin1_repo(self)
+        proc = mod._run_git_streaming(["log", "--patch"], root)
+        try:
+            text = "".join(proc.stdout)
+        finally:
+            proc.wait(timeout=10)
+            for stream in (proc.stdout, proc.stderr):
+                if stream is not None:
+                    stream.close()
+        self.assertIn("Alejandro", text)
+
+
+class TestUnknownArgumentsAndCommitCap(unittest.TestCase):
+    """Silent truncation must be visible in the envelope, not only on stderr."""
+
+    def test_unknown_flag_is_collected(self):
+        args = mod.parse_args(["src/", "--months", "420"])
+        self.assertIn("--months", args["unknown_args"])
+        self.assertEqual(args["days"], 90)
+
+    def test_known_flags_leave_unknown_args_empty(self):
+        self.assertEqual(mod.parse_args(["src/", "--days", "30"])["unknown_args"], [])
+
+    def test_unknown_flag_reaches_the_envelope(self):
+        root = _latin1_repo(self)
+        result = mod.analyze([str(root), "--months", "420", "--no-function"])
+        self.assertIn("--months", result["unknown_args"])
+        self.assertTrue(
+            any("Unrecognized argument" in n for n in result["notes"]),
+            result.get("notes"),
+        )
+
+    def test_commit_cap_is_noted(self):
+        root = _latin1_repo(self)
+        result = mod.analyze([str(root), "--max-commits", "1", "--no-function"])
+        self.assertTrue(result["time_range"]["commit_cap_applied"])
+        self.assertTrue(
+            any("COMMIT CAP APPLIED" in n for n in result["notes"]),
+            result.get("notes"),
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #27. Cross-toolkit propagation of a defect found while auditing cpython-review-toolkit — all five siblings carried the identical shape (two `text=True` subprocess sites with no `errors=`).

- **`errors="replace"` on both git subprocess sites.** A single non-UTF-8 byte in git output aborted the entire analysis. On CPython this took a full-history run from `UnicodeDecodeError` to completing in ~11 s.
- **Unknown `--` flags are surfaced** rather than silently dropped, so a mistyped window flag can no longer produce a confident wrong answer.
- **`commit_cap_applied` promoted into `notes[]`**, so a truncated analysis no longer reads as complete.

Test suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ko7pYv9LY8wCj87eMH93oD
