### PR TITLE
Close the calibration-loop gap: shared utilities, bug-shape catalog, informed-explore, and a correctness scanner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,5 +160,5 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,59 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **New agent + script: `python-pitfall-scanner` / `scan_python_pitfalls.py`** — the toolkit's first
+  dedicated bug-finding capability. Fourteen AST checks mapping 1:1 to the shapes in
+  `python_bug_shapes.json`, each emitting a confidence level (`high`/`medium`/`low`) derived from that
+  shape's differential. The builtin exception hierarchy is read from the running interpreter rather
+  than a hardcoded table, so `except`-ordering analysis is always correct for the Python in use.
+  Options: `--check ID[,ID...]` to select shapes and `--exclude PAT[,PAT...]` to drop generated trees.
+  Output includes a `by_directory` breakdown, because real-world runs showed generated content
+  (report artifacts, golden fixtures) is the dominant false-positive source and is best triaged a
+  directory at a time.
+- Registered the `pitfalls` aspect in `explore`, and put `python-pitfall-scanner` first in Group B —
+  behavioural bugs rank above code smells.
+- New shared module: `scan_common.py` — the utilities every analysis script needs (project-root
+  detection, file discovery, AST parsing, CLI parsing, the JSON envelope, finding deduplication).
+  Every script now imports from it. Previously `find_project_root` was byte-identical in all nine
+  scripts and `discover_python_files` had drifted into three divergent variants.
+- New data catalog: `data/python_bug_shapes.json` — 14 reusable Python bug *shapes* (not file:line),
+  each with its guarded twin (the fix pattern), a sibling-hunt directive, expected behavior, how the
+  defect surfaces, and a differential for when *not* to flag it. Covers mutable default arguments,
+  late-binding closures, unreachable `except` ordering, `return`-in-`finally`, `__eq__` without
+  `__hash__`, mutation during iteration, the asyncio family (fire-and-forget tasks, blocking calls in
+  `async def`, un-awaited coroutines), `lru_cache` on methods, shared class-level mutable attributes,
+  bare `except`, exceptions in `__del__`, and `is`-with-a-literal.
+- New data catalog: `data/python_non_bugs.md` — false-positive taxonomy in 15 classes, each stating
+  the symptom, why it is a non-bug, and what the real bug looks like so genuine instances are never
+  suppressed.
+- New script: `build_informed_briefing.py` — assembles the informed-review briefing (bug shapes
+  scoped per agent + false-positive taxonomy + cross-cutting triage rules) as Markdown. Folds in a
+  target project's accumulated findings memory from `.code-review/findings.json` when present, using
+  a schema wire-compatible with the `*-review-findings` companion repositories.
+- New command: `informed-explore` — same coverage as `explore`, but every agent reads the briefing
+  first, so a run hunts un-found siblings of established shapes instead of re-deriving basics.
+  Records confirmed findings to `.code-review/findings.json` for the next run.
 - New agent: `test-investigation-agent` — finds bugs by treating tests as invariant specifications. Reads existing tests to extract what developers believe should be true, maps those beliefs to structurally similar code, and checks whether the invariants hold everywhere they should.
 - New script: `extract_test_invariants.py` — supporting script that extracts assertions from test files, classifies invariant types, maps tests to source functions, and finds structurally similar functions using name-pattern and signature matching. Three-tier test selection (bug-fix tests, error/boundary tests, churn-guided) with 30-test budget cap.
 - Added `test-invariants` aspect to the explore command (Group D).
+- `explore` now supports `--runs N` (independent naive passes, deduplicated across runs) and
+  `--informed-reruns` (with `--runs 3`, the third pass targets adjacent code and structural siblings
+  of what the earlier passes confirmed). Documents the 2-naive-plus-1-informed review shape.
+- `CLAUDE.md` — development guide covering architecture, conventions, the data catalogs and their
+  `validation` grades, gotchas, and an explicit list of known gaps.
+
+### Fixed
+
+- `--max-files` with a non-integer argument now exits with a JSON error instead of an unhandled
+  `ValueError` traceback.
+- Documentation drift: both READMEs claimed 14 agents / 4 commands / 7 helper scripts; the actual
+  counts are 16 / 5 / 12 as of this release.
+- `correlate_tests.py` omitted `scan_root` from its JSON envelope, unlike every other script.
+- `scan_python_pitfalls.py` scopes a single-file target to that file. Several sibling scripts instead
+  fall back to the project root, silently turning "scan this file" into "scan everything".
+- `extract_test_invariants.py` emitted `invariant_types` in set-iteration order, so output varied
+  between runs with `PYTHONHASHSEED`. Output is now sorted and reproducible — non-reproducible output
+  would otherwise defeat cross-run deduplication under `explore --runs N`.
 
 ## [1.3.0] - 2026-03-16
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,210 @@
+# CLAUDE.md — code-review-toolkit development guide
+
+## Project overview
+code-review-toolkit is a [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugin for
+reviewing **Python source code**. It answers: *where are the problems in this codebase, and what
+should I fix first?*
+
+The original member of a family of review toolkits:
+
+| Toolkit | Target | Parsing |
+|---|---|---|
+| **code-review-toolkit** | Python source (this project) | `ast` |
+| [cext-review-toolkit](https://github.com/devdanzin/cext-review-toolkit) | CPython C extensions | Tree-sitter |
+| [cpython-review-toolkit](https://github.com/devdanzin/cpython-review-toolkit) | CPython runtime C | Tree-sitter |
+| [ft-review-toolkit](https://github.com/devdanzin/ft-review-toolkit) | Free-threading safety in C ext | Tree-sitter |
+| [rust-ext-review-toolkit](https://github.com/devdanzin/rust-ext-review-toolkit) | PyO3 extensions | Tree-sitter (Rust) |
+| [pyo3-review-toolkit](https://github.com/devdanzin/pyo3-review-toolkit) | PyO3 itself | Tree-sitter (Rust) |
+| [rustpy-review-toolkit](https://github.com/devdanzin/rustpy-review-toolkit) | RustPython interpreter | Tree-sitter (Rust) |
+
+Key difference from the siblings: they target *compiled-language* code where the dominant defects are
+crashes (segfaults, refcount errors, data races, panics). This toolkit targets Python, where the
+dominant defects are **silent** — wrong results, swallowed errors, shared mutable state — and where
+the analysis surface is `ast` rather than Tree-sitter.
+
+## Prerequisites
+- Python 3.10+ (uses `X | Y` union syntax)
+- **No required dependencies** — all scripts use only the standard library
+- Optional, for richer analysis: `ruff`, `mypy`, `vulture`, `coverage` (integrated via
+  `run_external_tools.py`; every agent works fully without them)
+
+## Dev commands
+```bash
+# Run all tests (must be run via discover — tests import helpers.py from tests/)
+python -m unittest discover tests -v
+
+# Run one test module
+python -m unittest discover tests -p "test_scan_common.py" -v
+
+# Run a script standalone (all output JSON to stdout)
+python plugins/code-review-toolkit/scripts/measure_complexity.py /path/to/project
+python plugins/code-review-toolkit/scripts/build_informed_briefing.py /path/to/project
+
+# Lint and format (scope to the files you changed)
+ruff format <changed-files>
+ruff check <changed-files>
+```
+
+> The repository has no ruff config and is **not** uniformly `ruff format`-clean — running
+> `ruff format` across the whole tree rewrites ~1500 lines of untouched code. Format only what you
+> changed, so a review diff stays reviewable. Normalizing the whole tree is worth doing, but as its
+> own formatting-only commit.
+
+> Tests **must** run through `unittest discover`; invoking `python -m unittest tests.test_x` fails
+> with `ModuleNotFoundError: No module named 'helpers'` because discovery is what puts `tests/` on
+> `sys.path`.
+
+## Project structure
+
+This is a Claude Code plugin, not a pip-installable package.
+
+```
+code-review-toolkit/
+├── CLAUDE.md                        # This file
+├── README.md                        # User-facing docs
+├── CHANGELOG.md                     # Keep a Changelog format
+├── plugins/code-review-toolkit/
+│   ├── .claude-plugin/plugin.json
+│   ├── agents/                      # 16 agent prompt definitions (markdown)
+│   ├── commands/                    # 5 command definitions (markdown)
+│   ├── scripts/                     # 12 Python scripts (the core code)
+│   └── data/                        # bug-shape catalog + FP taxonomy
+└── tests/                           # unittest suite
+```
+
+## Architecture
+
+### Scripts
+
+All in `plugins/code-review-toolkit/scripts/`. Every analysis script parses Python with `ast`, finds
+candidates, and prints JSON to stdout.
+
+| Script | Purpose |
+|---|---|
+| `scan_common.py` | **Shared utilities — every other script imports from here** |
+| `scan_python_pitfalls.py` | Correctness defects; 14 checks mapping 1:1 to `data/python_bug_shapes.json` |
+| `analyze_imports.py` | Import graph, module boundaries, circular dependencies |
+| `analyze_history.py` | Git history: churn, co-change, fix density |
+| `measure_complexity.py` | Per-function complexity metrics |
+| `find_dead_symbols.py` | Unused imports, unreferenced symbols, orphan files |
+| `correlate_tests.py` | Source ↔ test file correlation |
+| `count_types.py` | Type annotation coverage and type design patterns |
+| `collect_debt.py` | TODO/FIXME/HACK inventory with git-blame aging |
+| `extract_test_invariants.py` | Extracts assertions as invariant specs |
+| `run_external_tools.py` | ruff / mypy / vulture / coverage integration |
+| `build_informed_briefing.py` | Assembles the informed-explore briefing from `data/` |
+
+**Dependency graph:** `scan_common.py` is at the center; every other script imports from it. No
+circular dependencies.
+
+**Script calling convention:** each analysis script exposes `analyze(target: str, *, max_files: int
+= 0) -> dict` and a `main()` that prints JSON. Exceptions: `analyze_history.py` takes `argv`;
+`build_informed_briefing.py` prints **Markdown**, not JSON, because its output *is* the agent briefing.
+
+### The shared JSON envelope
+
+Every analysis script's output starts with the envelope from `scan_common.build_envelope()`:
+
+```json
+{"project_root": "...", "scan_root": "...", "files_total": 120,
+ "files_analyzed": 120, "files_capped": false}
+```
+
+`files_capped` tells an agent the results are partial because `--max-files` truncated the scan — say
+so in the report rather than presenting partial results as complete.
+
+### Data files (`plugins/code-review-toolkit/data/`)
+
+This is the toolkit's **memory**, and the thing that makes `informed-explore` work:
+
+- `python_bug_shapes.json` — reusable bug *shapes* (not file:line). Each carries its `pattern`, its
+  `guarded_twin` (the fix, usually already present elsewhere in the same codebase), a `hunt`
+  directive for finding siblings, `expected` behavior, how it `caught_as` surfaces, a `differential`
+  (when NOT to flag), and a `validation` grade.
+- `python_non_bugs.md` — the false-positive taxonomy: what to dismiss, *why*, and what the real bug
+  looks like so a genuine instance is never suppressed.
+
+**`validation` grades:** `documented` = the semantics are specified in the Python docs/FAQ or enforced
+by a mainstream linter rule (real, but not yet confirmed by this toolkit); `confirmed` = a validation
+run found a true positive — cite it in `confirmed_examples`. **Promoting `documented` → `confirmed`
+is the calibration loop.**
+
+### Agents
+
+16 markdown files with YAML frontmatter (name, description) plus a structured prompt. Agents contain
+no analysis logic — they run a script, read the JSON, then do the qualitative review the script
+cannot. Scripts find candidates (with a real false-positive rate); agents confirm or dismiss them.
+
+Seven agents are **qualitative** (no backing script — they use Grep/Read directly):
+api-surface-reviewer, consistency-auditor, documentation-auditor, git-history-analyzer,
+pattern-consistency-checker, project-docs-auditor, silent-failure-hunter.
+
+### Commands
+
+- `explore` — full review; supports `--runs N` and `--informed-reruns` for multi-pass
+- `informed-explore` — same coverage, but every agent is seeded with the `data/` briefing first
+- `map` — architecture only, fast
+- `health` — scored dashboard, all agents in summary mode
+- `hotspots` — complexity + dead code + debt, ranked
+
+### Classification system
+
+Every finding is tagged:
+- **FIX** — a real defect: wrong behavior, silent data loss, a crash
+- **CONSIDER** — likely improvement, may carry migration cost
+- **POLICY** — a design decision for the maintainer
+- **ACCEPTABLE** — noted, no action needed
+
+## Testing notes
+- All tests use `unittest` — **never pytest**
+- `tests/helpers.py` provides `TempProject` (context manager writing a temp project, including a
+  `pyproject.toml` so `find_project_root` works) and `import_script()` (importlib loader)
+- New script → add at minimum: a true positive, a true negative, and an edge case
+
+## Adding a new analysis script
+
+1. Create `plugins/code-review-toolkit/scripts/scan_newcheck.py`
+2. `sys.path.insert(0, str(Path(__file__).resolve().parent))`, then import from `scan_common` —
+   **never re-implement `find_project_root` or `discover_python_files`**
+3. Implement `analyze(target, *, max_files=0) -> dict` using `build_envelope()`
+4. Add `main()` using `parse_common_args()`
+5. Add `tests/test_scan_newcheck.py`
+6. Add `plugins/code-review-toolkit/agents/<name>.md`
+7. Register the agent in the right phase group in `commands/explore.md`
+8. Update `CHANGELOG.md` **and the agent/script/command counts in both READMEs**
+
+## Gotchas
+
+- **`scan_common.py` exists because of real decay.** Before it, `find_project_root` was
+  byte-identical in all nine scripts and `discover_python_files` had already drifted into three
+  divergent variants. Import; do not copy.
+- **Tests need `discover`.** See the note under *Dev commands*.
+- **`discover_python_files` is a generator.** Callers that slice or `len()` it must wrap in `list()`
+  (or use `collect_python_files`, which returns `(files, files_total)`).
+- **`parse_source()` returns `None` on bad input, and never raises.** Scans run over arbitrary
+  third-party trees; one unparseable file must never abort the run.
+- **`analyze_history.py` has a different `analyze()` signature** — it takes `argv`, matching the
+  sibling toolkits' convention but differing from every other script here.
+- **`build_informed_briefing.py` prints Markdown, not JSON.** It is the one deliberate exception to
+  the output contract.
+- **Keep the README counts honest.** Both READMEs state agent/script/command counts; they have drifted
+  before. Update them in the same commit that adds a component.
+
+## Known gaps (as of this writing)
+
+Tracked honestly so the next session does not have to re-derive them:
+
+1. **No validation runs.** `reports/` is empty, while sibling toolkits have between 1 and 67. This is
+   the root cause of gap 2 — no runs means no calibration data.
+2. **Every bug shape is `validation: documented`, none `confirmed`.** The catalog is grounded in
+   Python's documented semantics, not yet in findings from this toolkit.
+3. ~~All 14 bug shapes owned by one agent~~ **Done** — `python-pitfall-scanner` now owns them, backed
+   by `scan_python_pitfalls.py`, so every shape is executable rather than prompt-only.
+4. **No companion findings repository.** Every mature sibling has a `*-review-findings` repo. The
+   `.code-review/findings.json` schema written by `informed-explore` is deliberately
+   wire-compatible with those repos' `crate-local/findings.json`, so the memory can be lifted over
+   when the repo is created. Create it once there are real findings to put in it.
+5. **`known-issues` command not implemented.** It needs a regression catalog, which needs gap 1.
+
+## Workflow
+- Use `/task-workflow <description>` for the issue → branch → code → test → commit → PR → merge cycle

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Review Toolkit
 
-A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugin that bundles 14 specialized agents and 4 commands for exploring and analyzing existing codebases. It answers the question: **where are the problems in this codebase, and what should I fix first?**
+A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugin that bundles 16 specialized agents and 5 commands for exploring and analyzing existing codebases. It answers the question: **where are the problems in this codebase, and what should I fix first?**
 
 ## Installation
 
@@ -60,9 +60,10 @@ For your first time, start with `map` to understand the architecture, then `heal
 
 ## What's Included
 
-- **14 analysis agents** covering architecture, git history context, consistency, complexity, test coverage, error handling, documentation, project documentation accuracy, type design, dead code, tech debt, pattern consistency, API surface review, and git history analysis (fix propagation, churn×quality risk).
-- **4 commands** (`explore`, `map`, `hotspots`, `health`) for different analysis workflows.
-- **7 helper scripts** for complexity measurement, import analysis, dead symbol detection, test correlation, type counting, debt collection, and git history analysis.
+- **16 analysis agents** covering concrete correctness defects (mutable defaults, late-binding closures, unreachable `except` ordering, asyncio pitfalls), architecture, git history context, consistency, complexity, test coverage, error handling, documentation, project documentation accuracy, type design, dead code, tech debt, pattern consistency, API surface review, test-invariant investigation, and git history analysis (fix propagation, churn×quality risk).
+- **5 commands** (`explore`, `informed-explore`, `map`, `hotspots`, `health`) for different analysis workflows.
+- **12 helper scripts** for correctness scanning, complexity measurement, import analysis, dead symbol detection, test correlation, type counting, debt collection, test-invariant extraction, git history analysis, external-tool integration, shared utilities, and informed-briefing assembly.
+- **A bug-shape catalog and false-positive taxonomy** (`data/`) that power `informed-explore`, so a re-review hunts un-found siblings of known defect shapes instead of re-deriving the basics.
 
 For detailed usage, agent descriptions, and recommended workflows, see the [plugin README](plugins/code-review-toolkit/README.md).
 

--- a/plugins/code-review-toolkit/README.md
+++ b/plugins/code-review-toolkit/README.md
@@ -4,7 +4,7 @@ A comprehensive collection of specialized agents for exploring and analyzing exi
 
 ## Overview
 
-This plugin bundles 14 expert analysis agents and 4 commands. Each agent focuses on a specific aspect of code quality and is designed for codebase-scale analysis — scanning entire modules or projects rather than reviewing diffs.
+This plugin bundles 16 expert analysis agents and 5 commands. Each agent focuses on a specific aspect of code quality and is designed for codebase-scale analysis — scanning entire modules or projects rather than reviewing diffs.
 
 ### Key Design Principles
 
@@ -77,7 +77,7 @@ No third-party Python packages are required — all scripts use only the standar
 The primary command. Runs the foundational context providers (architecture-mapper + git-history-context) first, then dispatches selected agents with both structural and temporal context.
 
 ```bash
-# Full exploration (all 14 agents)
+# Full exploration (all 16 agents)
 /code-review-toolkit:explore
 
 # Specific directory
@@ -90,9 +90,32 @@ The primary command. Runs the foundational context providers (architecture-mappe
 /code-review-toolkit:explore . all summary
 ```
 
-**Aspects**: `architecture`, `history-context`, `history`, `history-full`, `consistency`, `complexity`, `tests`, `errors`, `docs`, `project-docs`, `types`, `dead-code`, `tech-debt`, `patterns`, `api`, `all`
+**Aspects**: `architecture`, `history-context`, `history`, `history-full`, `consistency`, `complexity`, `tests`, `pitfalls`, `errors`, `docs`, `project-docs`, `types`, `dead-code`, `tech-debt`, `test-invariants`, `patterns`, `api`, `all`
 
-**Options**: `deep` (full detail), `summary` (top-level only), `parallel` (concurrent agents)
+**Options**: `deep` (full detail), `summary` (top-level only), `parallel` (concurrent agents), `--runs N` (independent naive passes, deduplicated), `--informed-reruns` (with `--runs 3`, the third pass targets adjacent code and siblings of what runs 1–2 confirmed)
+
+### `/code-review-toolkit:informed-explore [scope] [aspects] [options]`
+
+Same coverage as `explore`, but every agent first reads a briefing assembled from the toolkit's
+catalogs: recurring Python bug **shapes** (each with its *guarded twin* — the fix pattern — and a
+sibling-hunt directive), the false-positive taxonomy, and the cross-cutting triage rules.
+
+The effect is fix-propagation: instead of re-deriving that a mutable default argument is a defect,
+the agent starts from the shape and hunts every un-found sibling of it.
+
+```bash
+# Thorough audit, or a re-review of a codebase already analyzed
+/code-review-toolkit:informed-explore
+
+# Just check whether the known shapes are present
+/code-review-toolkit:informed-explore . --shapes-only
+```
+
+Use `explore` for a first, unbiased look; use `informed-explore` when fix-propagation matters more
+than independence. For a high-stakes review, run both — naive passes first, informed pass last.
+
+Confirmed findings are recorded to `<scope>/.code-review/findings.json`, so the next informed run
+verifies them and moves on rather than re-litigating.
 
 ### `/code-review-toolkit:map [scope]`
 
@@ -137,6 +160,7 @@ Quick health dashboard — all agents in summary mode, producing a scored table 
 |-------|-------|-------------|
 | **test-coverage-analyzer** | Source↔test correlation, undertested modules, coverage gaps | pr-test-analyzer |
 | **pattern-consistency-checker** | Same concern solved different ways across modules | New |
+| **python-pitfall-scanner** | Concrete correctness defects: mutable defaults, late-binding closures, `except` ordering, `return`-in-`finally`, asyncio pitfalls, mutation-during-iteration | New |
 | **silent-failure-hunter** | Swallowed exceptions, bare except, silent error patterns | silent-failure-hunter |
 | **git-history-analyzer** | Fix completeness, similar bug detection, churn×quality risk matrix, historical context | New |
 

--- a/plugins/code-review-toolkit/agents/python-pitfall-scanner.md
+++ b/plugins/code-review-toolkit/agents/python-pitfall-scanner.md
@@ -1,0 +1,115 @@
+---
+name: python-pitfall-scanner
+description: Use this agent to find concrete correctness defects in Python code — the pitfalls that silently produce wrong results rather than raising. Covers mutable default arguments, late-binding closures in loops, unreachable `except` ordering, `return` inside `finally`, `__eq__` without `__hash__`, mutation during iteration, the asyncio family (fire-and-forget tasks, blocking calls in `async def`, un-awaited coroutines), `lru_cache` on methods, shared class-level mutable attributes, bare `except`, unguarded `__del__`, and `is`-with-a-literal. Backed by `scan_python_pitfalls.py`, whose checks map 1:1 to the shapes in `data/python_bug_shapes.json`.\n\n<example>\nContext: The user wants real bugs, not style feedback.\nuser: "Are there actual bugs in this codebase, not just code smells?"\nassistant: "I'll use the python-pitfall-scanner to find concrete correctness defects — the ones that silently produce wrong results."\n<commentary>\nThis is the toolkit's bug-finding agent, as opposed to the maintainability agents.\n</commentary>\n</example>\n\n<example>\nContext: An async service behaves nondeterministically under load.\nuser: "Tasks sometimes just don't run in our asyncio service."\nassistant: "I'll run the python-pitfall-scanner focused on the asyncio shapes — fire-and-forget tasks that get garbage-collected are the classic cause."\n<commentary>\nThe scanner's asyncio checks target exactly this symptom.\n</commentary>\n</example>
+model: inherit
+color: red
+---
+
+You find **concrete correctness defects** in Python code. You are not a style reviewer: your findings
+must be bugs that change behavior, and every one must come with a failure scenario a maintainer can
+reproduce mentally in one reading.
+
+Most of what you hunt is **silent**. It does not raise, it does not appear in logs, and the tests
+often pass — results are simply wrong, state bleeds between objects, or work never happens. That is
+precisely why static detection is worth doing here.
+
+## Phase 1 — Run the scanner
+
+```bash
+python <plugin_root>/scripts/scan_python_pitfalls.py [scope]
+```
+
+Useful options:
+- `--check ID[,ID...]` — restrict to specific shapes (ids match `data/python_bug_shapes.json`)
+- `--exclude PAT[,PAT...]` — drop paths containing a substring (see *Phase 2* — do this deliberately)
+- `--max-files N` — cap the scan
+
+The output envelope carries `summary.by_shape`, `summary.by_severity`, `summary.by_confidence`, and
+`summary.by_directory`, plus a `findings` list. Each finding has `shape`, `severity`, `confidence`,
+`file`, `line`, `message`, and `detail`.
+
+## Phase 2 — Read `by_directory` FIRST
+
+Before triaging anything, look at `summary.by_directory`. **If one directory dominates the counts,
+that is almost always generated content, not a defect cluster.** Observed in practice: report
+artifacts, golden/fixture files, vendored trees, and generated stress-test scripts routinely produce
+90%+ of raw findings.
+
+Triage the *directory*, not each hit:
+1. Check whether the dominant directory is hand-written source at all.
+2. If it is generated/vendored/fixture data, re-run with `--exclude <dir>/` and say so in your report
+   ("N findings suppressed in `<dir>/` — generated content").
+3. Never report a wall of findings from generated code. It buries the real ones and destroys trust in
+   the whole report.
+
+## Phase 3 — Triage each finding
+
+The scanner is tuned for **recall with an honest confidence signal**; you make the final call.
+
+- **`high`** — the differential does not apply. Verify quickly, then report.
+- **`medium`** — the shape matches but a legitimate reading exists. **You must check the code.** The
+  `detail` field states exactly what to check.
+- **`low`** — weak signal; useful mainly as a starting point for a sibling hunt.
+
+Read the actual source at every `file:line` before reporting. A finding you have not read is a
+hypothesis.
+
+Consult `data/python_non_bugs.md` for the false-positive taxonomy. Dismiss matching candidates **with
+the stated reason**; do not silently drop them and do not re-litigate classes the taxonomy settles.
+
+## Phase 4 — Hunt siblings (the highest-value step)
+
+For every confirmed finding, look up its shape in `data/python_bug_shapes.json` and follow the `hunt`
+directive. One confirmed instance almost always implies more:
+
+- A mutable default argument → check every sibling function with a similar signature.
+- A missed `await` → find the commit that made the function `async` and audit **every** caller.
+- A fire-and-forget task → grep every `create_task`/`ensure_future` site in the project.
+- A bare `except` in a worker loop → check every other long-running loop.
+
+Also find the **guarded twin**: the place in this same codebase that already handles the shape
+correctly. Cite it. It proves the defect by the project's own standard and hands the maintainer the
+fix in their own idiom.
+
+## Phase 5 — Report
+
+Group by shape, not by file — a maintainer fixes a shape once and applies it everywhere.
+
+```markdown
+### [SEVERITY] <shape id> — <n> instance(s)
+
+**What it is:** one sentence.
+**Why it is silent:** how it fails to announce itself.
+
+| # | Location | Confidence | Notes |
+|---|---|---|---|
+| 1 | `pkg/mod.py:42` | high | mutated on every call |
+
+**Failure scenario:** concrete inputs → wrong outcome.
+**Guarded twin:** `pkg/other.py:17` already does this correctly.
+**Fix:** the change, in the project's own idiom.
+**Siblings checked:** what the hunt covered, and what it found.
+```
+
+Then report, explicitly:
+- **Suppressed:** counts dismissed as generated content or per the FP taxonomy, with reasons.
+- **Novel shapes:** any correctness defect you found that no catalogued shape covers. Write it up in
+  the `python_bug_shapes.json` field structure (`pattern`, `guarded_twin`, `hunt`, `expected`,
+  `caught_as`, `differential`) so it can be added to the catalog. **This is the most valuable thing
+  you can return** — it extends the toolkit permanently.
+
+## Calibration notes
+
+- **`bare-except` is the highest-volume shape.** Most instances are in worker/thread bodies. The
+  discriminator: does control flow continue as if nothing happened (bug), or is the exception
+  captured/re-raised/reported so the caller can act (acceptable)? The scanner already downgrades the
+  capture pattern to `medium` — verify which one you have.
+- **`eq-without-hash` only matters if instances actually reach a set or dict key.** Check for that
+  before calling it a defect.
+- **`class-level-mutable-attribute` is fine for genuine constants.** ALL_CAPS names are already
+  downgraded; confirm whether anything mutates the object.
+- **`late-binding-closure-in-loop` is safe when the callable is consumed inside the same iteration.**
+  Trace whether it escapes the loop before reporting.
+- Do not report a shape merely because the scanner emitted it. **A confirmed-by-reading finding with
+  a failure scenario is worth more than ten unverified ones**, and the toolkit's credibility depends
+  on that ratio.

--- a/plugins/code-review-toolkit/commands/explore.md
+++ b/plugins/code-review-toolkit/commands/explore.md
@@ -26,6 +26,7 @@ Parse arguments into three categories:
 - `complexity` → complexity-simplifier
 - `tests` → test-coverage-analyzer
 - `errors` → silent-failure-hunter
+- `pitfalls` → python-pitfall-scanner (concrete correctness defects)
 - `docs` → documentation-auditor
 - `types` → type-design-analyzer
 - `dead-code` → dead-code-finder
@@ -44,6 +45,28 @@ Parse arguments into three categories:
 - `summary` → summary tier only (faster)
 - `parallel` → run agents concurrently where possible
 - `--max-parallel N` → cap concurrent agents per group (default: 2)
+- `--runs N` → run each agent N times (default: 1). Runs 2+ are **independent naive passes**: each
+  starts cold, with no knowledge of what earlier runs found. Deduplicate findings across runs by
+  `(file, line, finding type)`. If run 2 surfaces nothing new, report "high confidence — converged on
+  the first pass"; if it surfaces a lot, the analysis is under-saturated and a third run is warranted.
+- `--informed-reruns` → with `--runs 3`, the third pass receives a summary of runs 1–2 and this
+  instruction: *"These findings are already established. Look at ADJACENT code, unexplored error
+  paths, and patterns structurally similar to the confirmed findings that the prior passes missed."*
+  Targets fix-propagation rather than re-discovery.
+
+**On multi-pass reviews.** Independent naive passes work because a single pass saturates — one agent
+run explores one path through the codebase and stops. A second cold pass takes a different path.
+Only after the independent passes should an informed pass run, because a briefing biases toward what
+is already known; running it first would cost the independence that makes passes 1 and 2 worth doing.
+For a full audit the recommended shape is **2 naive passes + 1 informed pass**, synthesized into a
+single combined report:
+
+```
+/code-review-toolkit:explore . all --runs 3 --informed-reruns
+```
+
+If you want the informed pass seeded from the toolkit's shape catalog rather than only from this
+run's own findings, use [`informed-explore`](informed-explore.md) for the third pass instead.
 
 **Tool options** (passed to run_external_tools.py):
 - `--skip-tools` → skip external tool analysis entirely
@@ -113,24 +136,25 @@ Based on the requested aspects (default: all), launch the appropriate agents. Ea
 1. consistency-auditor
 2. pattern-consistency-checker
 
-**Group B — Code quality analysis**:
-3. complexity-simplifier
+**Group B — Correctness and code quality** (highest-value findings):
+3. **python-pitfall-scanner** — concrete correctness defects (runs first in this group: its findings are behavioural bugs, not smells)
 4. silent-failure-hunter
-5. dead-code-finder
+5. complexity-simplifier
+6. dead-code-finder
 
 **Group C — Interface and documentation**:
-6. test-coverage-analyzer
-7. documentation-auditor
-8. project-docs-auditor
-9. type-design-analyzer
-10. api-surface-reviewer
+7. test-coverage-analyzer
+8. documentation-auditor
+9. project-docs-auditor
+10. type-design-analyzer
+11. api-surface-reviewer
 
 **Group D — Inventory and investigation**:
-11. tech-debt-inventory
-12. test-investigation-agent
+12. tech-debt-inventory
+13. test-investigation-agent
 
 **Group E — Temporal analysis (runs last)**:
-13. git-history-analyzer
+14. git-history-analyzer
 
 If `parallel` is specified, run agents within each group concurrently. Run at most `--max-parallel` agents concurrently within each group (default: 2). On memory-constrained systems, use `--max-parallel 1` to run agents sequentially. Groups still execute sequentially because later groups may benefit from earlier findings. Group E runs last because it cross-references all other agents' output.
 

--- a/plugins/code-review-toolkit/commands/informed-explore.md
+++ b/plugins/code-review-toolkit/commands/informed-explore.md
@@ -1,0 +1,174 @@
+---
+description: "Like `explore`, but INFORMED: every agent first reads a briefing of recurring Python bug SHAPES (sibling-hunt templates with their guarded twins), the false-positive taxonomy, and the cross-cutting triage rules — so it confirms-without-relitigating, suppresses known FPs, and hunts un-found siblings of established shapes instead of re-discovering from scratch. Use for a thorough audit, a re-review of a codebase already analyzed, or whenever fix-propagation matters more than raw speed."
+argument-hint: "[scope] [aspects] [options]"
+allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
+---
+
+# Informed Codebase Review
+
+Same coverage as [`explore`](explore.md), but **informed**: agents are seeded with the toolkit's
+accumulated knowledge before they triage. That is what turns a cold, re-discovering pass into a
+**fix-propagation sweep** — instead of rediscovering that a mutable default argument is a bug, the
+agent starts from the shape and hunts every un-found sibling of it.
+
+**Arguments:** "$ARGUMENTS"
+
+**Plugin root:** `<plugin_root>` refers to the directory containing this command file's parent —
+i.e. the `plugins/code-review-toolkit/` directory. Resolve it relative to this file's location.
+
+## Argument Parsing
+
+Identical to [`explore`](explore.md) — scope, aspects, and options are parsed the same way. The
+informed run additionally honors:
+
+- `--catalog <path>` → also fold in an external findings catalog (see *Phase 1.5*).
+- `--shapes-only` → restrict each agent to hunting catalogued shapes and their siblings, skipping
+  open-ended analysis. Fastest way to answer "does this codebase have any of the known shapes?"
+
+## Execution Workflow
+
+### Phase 0: Project Discovery
+
+As in `explore`: identify the project layout, languages, and package structure.
+
+### Phase 0.5: External Tool Analysis (optional)
+
+As in `explore`: run ruff/mypy/vulture/coverage when available and keep the output for
+cross-referencing.
+
+### Phase 1: Foundational Context
+
+As in `explore`: run **architecture-mapper** and **git-history-context** first; their output feeds
+every later agent.
+
+### Phase 1.5: Build the informed briefing ← the step that makes this command different
+
+Generate the briefing once, then hand it to every agent:
+
+```bash
+python <plugin_root>/scripts/build_informed_briefing.py [scope] > /tmp/informed_briefing.md
+```
+
+For a per-agent briefing scoped to just the shapes that agent owns (shorter, more focused):
+
+```bash
+python <plugin_root>/scripts/build_informed_briefing.py [scope] --agent silent-failure-hunter
+```
+
+The briefing assembles three things:
+
+1. **Bug-shape templates** from `data/python_bug_shapes.json` — each with its *pattern*, its
+   *guarded twin* (the fix pattern, usually already present elsewhere in the same codebase), a
+   *sibling-hunt* directive, the *expected* behavior, and how the defect *surfaces* (most are
+   silent).
+2. **The false-positive taxonomy** from `data/python_non_bugs.md` — the classes to dismiss *with a
+   stated reason*, each paired with what the real bug looks like so a genuine instance is never
+   suppressed.
+3. **Cross-cutting triage rules** — guarded-twin, systemic-root-over-instance-count, silent-beats-
+   loud, behavioural-divergence-outranks-stylistic, confirm-don't-re-litigate, cite-or-drop.
+
+If the target codebase carries a findings memory at `<scope>/.code-review/findings.json` from prior
+runs, its **confirmed** entries are folded in automatically as "verify, then move on" items. Pass
+`--catalog <path>` to fold in an external catalog as well.
+
+### Phase 2: Targeted Analysis (informed)
+
+Dispatch the same agent groups as `explore` (Groups A–E). The difference is the prompt: **prepend
+the briefing to every agent's instructions**, followed by:
+
+> Before your own analysis, read the briefing above. Then:
+> 1. **Hunt the shapes you own.** For each template, search this codebase for instances. Report
+>    `file:line` plus a concrete failure scenario for each.
+> 2. **Follow the sibling hunt.** For every instance you confirm, run that shape's hunt directive —
+>    this is where a cold pass loses findings. One confirmed instance usually implies several.
+> 3. **Find the guarded twin.** Locate the place in this codebase that already handles the shape
+>    correctly. Cite it: it proves the shape is a defect by the project's own standard, and it is the
+>    fix to propose.
+> 4. **Suppress known false positives** using the taxonomy — dismiss with the stated reason rather
+>    than reporting. Do not re-litigate what the taxonomy already settles.
+> 5. **Do not re-derive established findings.** Confirm they still exist, then spend your effort on
+>    what is *not* yet known.
+> 6. **Then** do your own open-ended analysis for anything the catalog does not cover — a new shape
+>    is the most valuable thing you can return, because it extends the catalog.
+
+Agents must clearly separate the two kinds of output:
+
+- **Catalogued** — instances of a known shape (cite the shape `id`).
+- **Novel** — something no shape covers. Propose it as a *new* shape using the
+  `python_bug_shapes.json` field structure so it can be added to the catalog.
+
+### Phase 3: Synthesis (+ record to the project memory)
+
+Produce the same report as `explore`, with three additions:
+
+1. **Shape coverage table** — for every catalogued shape: instances found, sibling sites, and
+   whether a guarded twin exists in this codebase.
+
+   | Shape | Instances | Sibling sites | Guarded twin present | Verdict |
+   |---|---|---|---|---|
+
+2. **Proposed new shapes** — novel findings written in the catalog's field structure, ready to be
+   appended to `data/python_bug_shapes.json`.
+
+3. **Proposed new false-positive classes** — anything an agent flagged that triage dismissed, with
+   the reason and the real-bug discriminator, ready for `data/python_non_bugs.md`.
+
+Then **write the findings memory** so the next run is informed, at
+`<scope>/.code-review/findings.json`:
+
+```json
+{
+  "project": "<name>",
+  "schema_version": 1,
+  "findings": [
+    {
+      "id": "CRT-0001",
+      "severity": "FIX",
+      "title": "Mutable default argument in load_config()",
+      "location": "pkg/config.py:42",
+      "shape": "mutable-default-argument",
+      "status": "confirmed",
+      "evidence": "calling load_config() twice accumulates entries from the first call"
+    }
+  ]
+}
+```
+
+`status` is one of `confirmed` (verified true positive), `reported` (raised upstream), `fixed`, or
+`candidate` (unverified — **not** folded into future briefings). Only the first three are treated as
+established. This schema matches `crate-local/findings.json` in the `*-review-findings` companion
+repositories, so a project's memory can be lifted into a findings repo unchanged.
+
+## Extending the catalogs
+
+The catalogs are the toolkit's memory, and every run should improve them:
+
+- A **confirmed novel finding** → add a shape to `data/python_bug_shapes.json`. Set
+  `"validation": "confirmed"` and cite the instance in `confirmed_examples`.
+- A **dismissed false positive** → add a class to `data/python_non_bugs.md`, including the
+  discriminator that separates it from the real bug.
+- A shape that was `"documented"` and is now confirmed in a real codebase → promote it to
+  `"validation": "confirmed"`. **That promotion is the calibration loop.**
+
+## When to use `explore` vs `informed-explore`
+
+| Situation | Command |
+|---|---|
+| First look at an unfamiliar codebase | `explore` |
+| Thorough audit, or fix-propagation matters | `informed-explore` |
+| Re-review of a codebase already analyzed | `informed-explore` (it will not re-litigate) |
+| You want independent, unbiased passes | `explore` (the briefing deliberately biases toward known shapes) |
+
+The bias is the point — and also the tradeoff. An informed run is better at finding *siblings of
+known shapes* and worse at noticing something genuinely unlike anything in the catalog. For a
+high-stakes review, run both: naive passes first for independence, then an informed pass for
+propagation.
+
+## Usage Examples
+
+```bash
+/code-review-toolkit:informed-explore                      # whole project, all agents
+/code-review-toolkit:informed-explore src/                 # narrowed scope
+/code-review-toolkit:informed-explore . --shapes-only      # just hunt the known shapes
+/code-review-toolkit:informed-explore . silent-failures    # one aspect, informed
+```

--- a/plugins/code-review-toolkit/data/python_bug_shapes.json
+++ b/plugins/code-review-toolkit/data/python_bug_shapes.json
@@ -1,0 +1,267 @@
+{
+  "schema_version": 1,
+  "_comment": "Python bug-SHAPE catalog for the informed-explore loop. PROJECT-INDEPENDENT: each entry is a reusable code SHAPE (not a file:line), its guarded twin (= the fix pattern), a sibling-hunt directive, `expected` (the behaviour the fix should produce), and `caught_as` (how the defect surfaces at runtime -- most of these are SILENT, which is exactly why a reviewer must look for them). `agent` names the owning agent (agents/<name>.md) and `detected_by` the script whose check implements the shape 1:1 (so a finding traces back to its template); `severity` is the DEFAULT before triage. `validation` records how well-grounded the shape is: `documented` = the semantics are specified in the Python docs/FAQ or enforced by a mainstream linter rule, so the shape is real even though this toolkit has not yet confirmed an instance; `confirmed` = a validation run in reports/ found a true positive (cite it in confirmed_examples). Promote shapes from `documented` to `confirmed` as reports land -- that promotion IS the calibration loop. build_informed_briefing.py turns these into per-run agent briefings.",
+  "shapes": [
+    {
+      "id": "mutable-default-argument",
+      "title": "Mutable object as a default parameter value -- shared across every call",
+      "agent": "python-pitfall-scanner",
+      "severity": "FIX",
+      "pattern": "A `def`/`async def` whose default is a mutable literal or call: `def f(items=[])`, `def f(opts={})`, `def f(s=set())`, `def f(now=datetime.now())`. The default is evaluated ONCE at function-definition time, so every call that mutates it sees the accumulated state of all prior calls.",
+      "guarded_twin": "The `None` sentinel: `def f(items=None): items = [] if items is None else items`. In most codebases the correct twin already exists on a sibling function -- find it and match it.",
+      "hunt": "For each confirmed instance, check every other function in the same module and every override/implementation of the same interface; this shape is copy-pasted along a family of similar signatures.",
+      "expected": "each call with the argument omitted starts from a fresh empty container (or a freshly-evaluated timestamp).",
+      "caught_as": "SILENT -- results that grow across calls, stale timestamps, or test pollution that only appears when tests run in a particular order. Never raises.",
+      "confirmed_examples": [],
+      "validation": "documented",
+      "references": [
+        "Python docs, 'Default parameter values are evaluated ... once' (tutorial 4.8.1)",
+        "ruff B006 / flake8-bugbear: mutable-argument-default"
+      ],
+      "differential": "A mutable default that is only ever READ (never mutated, never returned) is a style issue, not a bug -- do not report it as FIX. Read the body before classifying.",
+      "detected_by": "scan_python_pitfalls.py"
+    },
+    {
+      "id": "late-binding-closure-in-loop",
+      "title": "Closure captures the loop variable by reference, not by value",
+      "agent": "python-pitfall-scanner",
+      "severity": "FIX",
+      "pattern": "A `lambda` or nested `def` created inside a loop that references the loop variable: `handlers = [lambda: process(i) for i in items]`, or `for name in names: register(lambda: use(name))`. Every closure shares one cell and sees the FINAL value after the loop ends.",
+      "guarded_twin": "Bind at creation time via a default argument (`lambda i=i: process(i)`) or `functools.partial(process, i)`. A sibling loop in the same file that already does this is the fix pattern.",
+      "hunt": "Grep every loop body that constructs a callable -- callbacks, event handlers, retry wrappers, click/argparse command registration, and thread/task targets are the recurring hosts.",
+      "expected": "each closure operates on the loop value that was current when it was created.",
+      "caught_as": "SILENT -- every callback behaves as if it were the last iteration. Often mistaken for a race or a caching bug.",
+      "confirmed_examples": [],
+      "validation": "documented",
+      "references": [
+        "Python Programming FAQ, 'Why do lambdas defined in a loop with different values all return the same result?'",
+        "ruff B023 / flake8-bugbear: function-uses-loop-variable"
+      ],
+      "differential": "Safe when the closure is CALLED inside the same iteration (immediately consumed), or when the loop variable is not referenced in the closure body. Trace whether the callable escapes the iteration.",
+      "detected_by": "scan_python_pitfalls.py"
+    },
+    {
+      "id": "except-clause-ordering-unreachable",
+      "title": "A broad `except` precedes a narrower one, making the specific handler dead",
+      "agent": "python-pitfall-scanner",
+      "severity": "FIX",
+      "pattern": "In one `try` statement, an `except` naming a base class appears BEFORE an `except` naming its subclass -- `except Exception:` then `except ValueError:`, or `except OSError:` then `except FileNotFoundError:`. Python matches clauses top-to-bottom, so the specific branch can never run.",
+      "guarded_twin": "Most-specific-first ordering. The correct order usually already exists in a neighbouring try/except in the same module.",
+      "hunt": "For each hit, audit every try/except in the same error-handling layer -- ordering mistakes cluster where handlers were appended over time rather than inserted.",
+      "expected": "the specific handler runs for its exception type; the broad handler only catches what the specific ones did not.",
+      "caught_as": "SILENT -- the specialized recovery path (retry, fallback, targeted cleanup) is quietly replaced by the generic one.",
+      "confirmed_examples": [],
+      "validation": "documented",
+      "references": [
+        "Python reference, 'the try statement': clauses are tested in order",
+        "pylint E0701 bad-except-order"
+      ],
+      "differential": "Not a bug if the earlier clause re-raises unconditionally, or if the two types are unrelated (no subclass relationship) -- verify the MRO, do not assume from the names.",
+      "detected_by": "scan_python_pitfalls.py"
+    },
+    {
+      "id": "return-or-break-in-finally",
+      "title": "`return`/`break`/`continue` inside `finally` discards the in-flight exception",
+      "agent": "python-pitfall-scanner",
+      "severity": "FIX",
+      "pattern": "A `finally:` block containing `return`, `break`, or `continue`. Any exception propagating through the `try` is silently dropped when the `finally` transfers control, so the caller sees a normal return instead of the error.",
+      "guarded_twin": "Do the cleanup in `finally` but let control flow continue; put the `return` after the try/finally, or use a context manager.",
+      "hunt": "Audit every `finally` in the module; also check `__exit__` methods that `return True` unconditionally -- that is the same defect expressed through the context-manager protocol.",
+      "expected": "the original exception propagates to the caller; cleanup still runs.",
+      "caught_as": "SILENT -- errors vanish. A function that should have raised returns a normal (often `None`) value; failures surface far downstream as an unexpected `None`.",
+      "confirmed_examples": [],
+      "validation": "documented",
+      "references": [
+        "Python reference, 'the try statement': a return/break/continue in finally discards the pending exception",
+        "ruff B012 / flake8-bugbear; PEP 765 (3.14 warns on return-in-finally)"
+      ],
+      "differential": "`__exit__` returning a computed truthy value for a SPECIFIC exception type is a legitimate suppression idiom; an unconditional `return True` is the bug.",
+      "detected_by": "scan_python_pitfalls.py"
+    },
+    {
+      "id": "eq-without-hash",
+      "title": "`__eq__` defined without `__hash__` -- instances become unhashable or hash inconsistently",
+      "agent": "python-pitfall-scanner",
+      "severity": "CONSIDER",
+      "pattern": "A class defining `__eq__` but not `__hash__`. Python 3 sets `__hash__ = None`, so instances can no longer go in a `set` or be used as `dict` keys. The mirror defect: a class defining BOTH where `__hash__` does not agree with `__eq__` (equal objects hashing differently), which corrupts set/dict membership.",
+      "guarded_twin": "Define `__hash__` over the same fields `__eq__` compares, or use `@dataclass(frozen=True)`/`eq=True, frozen=True` which derives both consistently.",
+      "hunt": "Check every class in the module hierarchy that defines `__eq__`; also check whether instances are ever placed in a set, used as dict keys, or deduplicated -- that is where the breakage surfaces.",
+      "expected": "equal objects hash equally and can be used in hash-based containers.",
+      "caught_as": "`TypeError: unhashable type` at the first set/dict use (loud), OR -- when both are defined inconsistently -- SILENT duplicate entries and failed lookups.",
+      "confirmed_examples": [],
+      "validation": "documented",
+      "references": [
+        "Python data model, object.__hash__: 'If a class that overrides __eq__() needs to retain the hash ...'",
+        "pylint W1641 eq-without-hash"
+      ],
+      "differential": "Intentional for deliberately-unhashable mutable value objects. Only report when the type is actually used (or plausibly used) in a hash-based container.",
+      "detected_by": "scan_python_pitfalls.py"
+    },
+    {
+      "id": "mutation-during-iteration",
+      "title": "A container is mutated while being iterated",
+      "agent": "python-pitfall-scanner",
+      "severity": "FIX",
+      "pattern": "`for k in d:` with `del d[k]` / `d[new] = v` in the body; `for x in lst:` with `lst.remove(x)` / `lst.append(...)`; iterating a set while adding to it. Dict/set raise `RuntimeError: dictionary changed size during iteration`; LISTS DO NOT -- they silently skip elements as indices shift.",
+      "guarded_twin": "Iterate over a snapshot (`for k in list(d)`) or build a new container via comprehension and rebind.",
+      "hunt": "For each hit, check every loop in the same module that mutates its own iteration target; the list variant is the dangerous one because it never raises.",
+      "expected": "every element is visited exactly once, and the intended removals all happen.",
+      "caught_as": "`RuntimeError` for dict/set (loud); SILENT element-skipping for lists -- roughly every other element is missed.",
+      "confirmed_examples": [],
+      "validation": "documented",
+      "references": [
+        "Python docs, dict view objects: 'Iterating views while adding or deleting entries ... may raise RuntimeError'"
+      ],
+      "differential": "Safe when the mutation happens after a `break`, or when the loop iterates an explicit copy (`list(...)`, `.copy()`, a slice). Confirm the iterated expression is the SAME object being mutated.",
+      "detected_by": "scan_python_pitfalls.py"
+    },
+    {
+      "id": "asyncio-fire-and-forget-task",
+      "title": "`asyncio.create_task()` result is discarded -- the task can be garbage-collected mid-flight",
+      "agent": "python-pitfall-scanner",
+      "severity": "FIX",
+      "pattern": "`asyncio.create_task(coro())` / `loop.create_task(...)` / `ensure_future(...)` whose return value is not stored, awaited, or added to a set. The event loop keeps only a WEAK reference, so the task may be collected before it completes -- and any exception it raised is swallowed.",
+      "guarded_twin": "Retain a strong reference: keep a module/instance-level `set`, `add()` the task, and `task.add_done_callback(tasks.discard)`; or `await` it; or gather it.",
+      "hunt": "Grep every `create_task`/`ensure_future` call site; also check whether a task-exception handler exists at all -- a project with one retained-task set usually has other sites that forgot it.",
+      "expected": "the task runs to completion and its exception surfaces (logged or re-raised), not silently dropped.",
+      "caught_as": "SILENT and NONDETERMINISTIC -- work intermittently does not happen under load; exceptions never appear. Sometimes an 'Task was destroyed but it is pending!' warning.",
+      "confirmed_examples": [],
+      "validation": "documented",
+      "references": [
+        "asyncio docs, asyncio.create_task: 'Save a reference to the result ... the event loop only keeps weak references to tasks'"
+      ],
+      "differential": "Fine when the call is immediately awaited, gathered, or the returned task is assigned. A task stored ONLY in a local that goes out of scope is still the bug.",
+      "detected_by": "scan_python_pitfalls.py"
+    },
+    {
+      "id": "blocking-call-in-async-function",
+      "title": "A synchronous blocking call inside `async def` stalls the whole event loop",
+      "agent": "python-pitfall-scanner",
+      "severity": "FIX",
+      "pattern": "Inside an `async def`: `time.sleep(...)`, `requests.get(...)`, `open(...).read()` on a large file, `subprocess.run(...)`, a blocking DB driver call, or `socket` I/O. The coroutine holds the single event-loop thread, so every other task stops.",
+      "guarded_twin": "`await asyncio.sleep(...)`, an async client (`aiohttp`/`httpx.AsyncClient`), or `await asyncio.to_thread(fn, ...)` / `run_in_executor` for unavoidable blocking work. A sibling coroutine already doing this is the fix.",
+      "hunt": "Audit every `async def` in the module for imports of known-blocking libraries; a project mixing sync and async clients usually has several.",
+      "expected": "the coroutine yields to the loop while waiting; concurrent tasks continue.",
+      "caught_as": "SILENT -- manifests as latency, timeouts, and apparent deadlock under concurrency, never as an exception. Easily misread as a performance problem rather than a defect.",
+      "confirmed_examples": [],
+      "validation": "documented",
+      "references": [
+        "asyncio developer guide, 'Running Blocking Code'"
+      ],
+      "differential": "Acceptable at startup/shutdown before the loop is serving, or in a coroutine documented as running in an executor. Check whether the call is on the hot path.",
+      "detected_by": "scan_python_pitfalls.py"
+    },
+    {
+      "id": "unawaited-coroutine",
+      "title": "A coroutine function is called without `await` -- the body never runs",
+      "agent": "python-pitfall-scanner",
+      "severity": "FIX",
+      "pattern": "Calling an `async def` and discarding the result, or using it in a boolean/truthiness context: `self.flush()` where `flush` is async; `if self.check():`. A coroutine object is truthy, so guards silently take the wrong branch and the work never executes.",
+      "guarded_twin": "`await self.flush()`, or `asyncio.create_task(...)` WITH a retained reference (see asyncio-fire-and-forget-task).",
+      "hunt": "For each async method, grep every call site; the shape appears when a previously-sync method is converted to async and one caller is missed. Check git history for the sync->async commit and audit all callers touched (or not touched) by it.",
+      "expected": "the coroutine body executes and its result/exception is observed.",
+      "caught_as": "A `RuntimeWarning: coroutine '...' was never awaited` (easily lost in log noise, and only if the object is collected); otherwise SILENT no-op.",
+      "confirmed_examples": [],
+      "validation": "documented",
+      "references": [
+        "CPython emits RuntimeWarning 'coroutine ... was never awaited'",
+        "ruff RUF006 / ASYNC family"
+      ],
+      "differential": "Deliberate when the coroutine object is passed to `gather`/`wait`/`create_task` or returned to a caller that awaits it. Follow the value.",
+      "detected_by": "scan_python_pitfalls.py"
+    },
+    {
+      "id": "lru-cache-on-method",
+      "title": "`@lru_cache` on an instance method keeps every `self` alive forever",
+      "agent": "python-pitfall-scanner",
+      "severity": "CONSIDER",
+      "pattern": "`@functools.lru_cache` / `@cache` applied to a method taking `self`. The cache is stored on the CLASS and keys include `self`, so every instance ever passed is strongly referenced for the process lifetime -- an unbounded leak -- and cache entries are shared across instances.",
+      "guarded_twin": "`functools.cached_property` for per-instance memoization, a per-instance cache dict built in `__init__`, or making the function a `@staticmethod`/module-level function keyed only on the real inputs.",
+      "hunt": "Grep every `lru_cache`/`cache` decorator and check whether the first parameter is `self`/`cls`; long-lived services accumulate these.",
+      "expected": "cached values are released when the instance is; memory is stable across instance churn.",
+      "caught_as": "SILENT -- steadily growing RSS in a long-running process; instances that should be collected never are.",
+      "confirmed_examples": [],
+      "validation": "documented",
+      "references": [
+        "functools docs, lru_cache note on methods and object lifetimes",
+        "ruff B019 / flake8-bugbear: cached-instance-method"
+      ],
+      "differential": "Harmless for singletons or classes with a small fixed instance count. Judge by instance lifecycle, not by the decorator alone.",
+      "detected_by": "scan_python_pitfalls.py"
+    },
+    {
+      "id": "class-level-mutable-attribute",
+      "title": "A mutable class attribute is shared by every instance",
+      "agent": "python-pitfall-scanner",
+      "severity": "FIX",
+      "pattern": "`class C: items = []` (or `{}`/`set()`) where instances mutate `self.items.append(...)`. Because the attribute lives on the class, all instances share one object; only REBINDING (`self.items = [...]`) creates a per-instance copy.",
+      "guarded_twin": "Initialize in `__init__` (`self.items = []`), or use `dataclasses.field(default_factory=list)`.",
+      "hunt": "Audit every class-body assignment to a mutable literal in the module; also check dataclasses for a bare mutable default (which raises at class-creation time and so is self-correcting -- the plain-class form is the silent one).",
+      "expected": "each instance owns its own container.",
+      "caught_as": "SILENT -- state bleeds between instances; frequently first noticed as cross-test contamination.",
+      "confirmed_examples": [],
+      "validation": "documented",
+      "references": [
+        "Python tutorial 9.3.5, 'Class and Instance Variables' (shared mutable warning)"
+      ],
+      "differential": "Correct and idiomatic for CONSTANTS that are never mutated (and better expressed as a tuple/frozenset). Confirm a mutation exists before reporting.",
+      "detected_by": "scan_python_pitfalls.py"
+    },
+    {
+      "id": "bare-except-swallows-control-flow",
+      "title": "`except:` / `except BaseException:` swallows KeyboardInterrupt and SystemExit",
+      "agent": "python-pitfall-scanner",
+      "severity": "FIX",
+      "pattern": "A bare `except:` or `except BaseException:` whose handler does not re-raise. These catch `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit` -- so Ctrl-C is ignored, `sys.exit()` is neutralized, and shutdown hangs. Worse inside a retry loop, which will spin forever against Ctrl-C.",
+      "guarded_twin": "`except Exception:` (which excludes the control-flow exceptions), or a bare except that re-raises after cleanup.",
+      "hunt": "Every bare except in the codebase; prioritize those inside loops, signal handlers, and long-running worker/daemon bodies.",
+      "expected": "Ctrl-C interrupts promptly; `sys.exit()` terminates the process.",
+      "caught_as": "SILENT until an operator tries to stop the process and cannot -- then it looks like a hang, not an exception-handling bug.",
+      "confirmed_examples": [],
+      "validation": "documented",
+      "references": [
+        "Python docs, exception hierarchy: KeyboardInterrupt/SystemExit derive from BaseException, not Exception",
+        "ruff E722 bare-except; pylint W0702"
+      ],
+      "differential": "Legitimate in a top-level crash-reporting boundary that logs and RE-RAISES, and in `__del__`/atexit cleanup. The discriminator is whether control flow continues as if nothing happened.",
+      "detected_by": "scan_python_pitfalls.py"
+    },
+    {
+      "id": "exception-in-del-or-finalizer",
+      "title": "`__del__` raises or resurrects -- the exception is discarded and cleanup is skipped",
+      "agent": "python-pitfall-scanner",
+      "severity": "CONSIDER",
+      "pattern": "A `__del__` that performs failure-prone work (I/O, network close, dict lookups on possibly-torn-down module globals) with no guard. Exceptions in `__del__` are printed and ignored -- never propagated -- so the remainder of the finalizer silently does not run. At interpreter shutdown module globals may already be `None`.",
+      "guarded_twin": "`weakref.finalize` or an explicit `close()`/context manager; if `__del__` is unavoidable, wrap the whole body in try/except and hold direct references to anything it needs.",
+      "hunt": "Every `__del__` in the codebase, plus classes owning an OS resource (file, socket, subprocess, lock) that rely on `__del__` for release.",
+      "expected": "resources are released deterministically; failures are visible.",
+      "caught_as": "SILENT -- 'Exception ignored in: <function C.__del__>' on stderr at best; leaked file descriptors/sockets at worst.",
+      "confirmed_examples": [],
+      "validation": "documented",
+      "references": [
+        "Python data model, object.__del__: exceptions that occur are ignored; warnings about interpreter shutdown"
+      ],
+      "differential": "A trivially-safe `__del__` (pure attribute assignment) is fine. Rank by what the body can actually raise.",
+      "detected_by": "scan_python_pitfalls.py"
+    },
+    {
+      "id": "is-comparison-with-literal",
+      "title": "Identity comparison against a literal -- works only by interning accident",
+      "agent": "python-pitfall-scanner",
+      "severity": "CONSIDER",
+      "pattern": "`x is 0`, `x is 'name'`, `x is 256`, `status is ''`. `is` compares identity; small-int caching and string interning make this appear to work in testing and then fail for computed or large values.",
+      "guarded_twin": "`==` for value comparison; keep `is` for `None`, `True`, `False`, and genuine sentinels.",
+      "hunt": "Grep `is` / `is not` followed by a numeric or string literal across the codebase.",
+      "expected": "comparison is by value and holds for every equal value, not just interned ones.",
+      "caught_as": "`SyntaxWarning: \"is\" with a literal` at compile time on modern CPython; otherwise SILENT and input-dependent -- passes for small values, fails for large ones.",
+      "confirmed_examples": [],
+      "validation": "documented",
+      "references": [
+        "CPython emits SyntaxWarning for `is` with a literal (3.8+)",
+        "ruff F632 is-literal"
+      ],
+      "differential": "`is None` / `is True` / `is False` and sentinel-object comparisons are correct and must not be flagged.",
+      "detected_by": "scan_python_pitfalls.py"
+    }
+  ]
+}

--- a/plugins/code-review-toolkit/data/python_non_bugs.md
+++ b/plugins/code-review-toolkit/data/python_non_bugs.md
@@ -1,0 +1,145 @@
+# Python-review false-positive taxonomy
+
+The recurring shapes a high-recall scanner or agent flags but a reviewer should **dismiss with a
+reason**, plus how to tell each apart from the *real* bug it mimics. This is the reasoning companion
+to `python_bug_shapes.json`; `build_informed_briefing.py` folds both into the informed-explore
+briefing so agents stop re-triaging these from scratch.
+
+Extend it as validation runs confirm new FP classes — that feedback is what calibrates the toolkit.
+Each class: **symptom** (what gets flagged) → **why it's a non-bug** → **what the REAL bug looks
+like** (so a genuine instance is never suppressed).
+
+---
+
+## Dead code / unused symbols
+
+### 1. Dynamically-dispatched name
+- **Symptom:** a function/method/class reported as unreferenced.
+- **Why non-bug:** Python reaches it without a literal reference — `getattr(obj, name)`, a registry
+  populated by decorator, `__init_subclass__`, entry points in `pyproject.toml`, a plugin loader,
+  `globals()[name]`, Django/SQLAlchemy/pydantic model hooks, or a name only used in a template or
+  config string.
+- **Real bug:** genuinely nothing constructs the name — no decorator registry, no entry point, no
+  string occurrence anywhere including non-Python files. **Grep the whole repo for the bare name
+  (including `.toml`, `.cfg`, `.ini`, `.yaml`, `.html`) before reporting.**
+
+### 2. Public API surface of a library
+- **Symptom:** exported functions unreferenced *within* the package.
+- **Why non-bug:** the consumers are downstream users, not this repo. Anything in `__all__`, or
+  re-exported from `__init__.py`, is API by definition.
+- **Real bug:** an internal helper (leading underscore, not in `__all__`, not re-exported) with no
+  in-repo callers.
+
+### 3. Protocol / ABC / override conformance
+- **Symptom:** a method that "no one calls" — `__enter__`, `visit_*`, `do_GET`, `setUp`, an
+  overridden base method.
+- **Why non-bug:** the caller is the language, the framework, or a base class. Visitor methods
+  (`ast.NodeVisitor.visit_*`), unittest fixtures, and dunder protocol methods are dispatched by name.
+- **Real bug:** a `visit_X`/`do_X` whose suffix matches no real node type or verb — a typo'd hook
+  that will never fire. That one IS worth reporting.
+
+### 4. Test-only helper
+- **Symptom:** a symbol used exclusively from `tests/`.
+- **Why non-bug:** that is its purpose.
+- **Real bug:** a symbol used by *nothing*, including tests.
+
+---
+
+## Error handling
+
+### 5. Intentional narrow suppression
+- **Symptom:** an `except ...: pass`.
+- **Why non-bug:** it catches a *specific* exception it can legitimately ignore, and the intent is
+  documented — `except FileNotFoundError: pass` around a best-effort cleanup, `contextlib.suppress`.
+- **Real bug:** the suppressed type is broad (`Exception`/bare), or the body swallows an error the
+  caller needed in order to be correct. See `bare-except-swallows-control-flow` for the
+  `BaseException` variant, which is a real bug regardless of intent.
+
+### 6. Re-raising boundary handler
+- **Symptom:** a broad `except Exception:` at a top-level entry point.
+- **Why non-bug:** it logs, adds context, and **re-raises** (or deliberately converts to an exit
+  code at the true process boundary — a CLI `main()`, a request handler, a worker loop that must not
+  die on one bad item).
+- **Real bug:** the same shape with no re-raise and no logging, in the middle of a call stack, where
+  the caller cannot tell the operation failed.
+
+### 7. `logging.exception` inside the handler
+- **Symptom:** an exception "swallowed" but logged.
+- **Why non-bug:** at a genuine boundary, logging with traceback and continuing is the designed
+  behavior.
+- **Real bug:** logged at `debug`/`info` level, or logged without the traceback (`logger.error(str(e))`),
+  so the failure is invisible in production — and control continues as if it succeeded.
+
+---
+
+## Complexity / structure
+
+### 8. Inherently-complex dispatch
+- **Symptom:** a function scoring high on branch count / cognitive complexity.
+- **Why non-bug:** it is a flat dispatch table — a long `match`/`if-elif` over opcodes, token types,
+  or message kinds, or generated/vendored code. Splitting it would *reduce* readability.
+- **Real bug:** deep NESTING (4+ levels) mixing distinct concerns, or a long function where extract-
+  method would produce independently-nameable units. Judge nesting depth over raw length.
+
+### 9. Parser / state machine
+- **Symptom:** high complexity in a tokenizer, parser, or protocol decoder.
+- **Why non-bug:** state machines are irreducibly branchy; the complexity is essential, not accidental.
+- **Real bug:** a state machine whose states are implicit in ad-hoc booleans rather than an enum —
+  that is a real refactor target.
+
+---
+
+## Types
+
+### 10. Deliberate `Any` at a boundary
+- **Symptom:** `Any` flagged as weak typing.
+- **Why non-bug:** it sits at a genuinely dynamic edge — deserialized JSON, `**kwargs` passthrough,
+  a decorator wrapping arbitrary callables, or a C-extension boundary.
+- **Real bug:** `Any` on an internal function whose actual type is known and stable, especially when
+  a `TypedDict`/dataclass for that shape already exists in the codebase.
+
+### 11. Missing annotations in a deliberately-untyped area
+- **Symptom:** low annotation coverage.
+- **Why non-bug:** the project is gradually typed and this module is explicitly excluded in
+  `pyproject.toml`/`mypy.ini`, or it is test code where annotations add little.
+- **Real bug:** an unannotated *public* API in a package that otherwise ships `py.typed`.
+
+---
+
+## Consistency / patterns
+
+### 12. Justified local divergence
+- **Symptom:** one module handles a concern differently from the majority.
+- **Why non-bug:** the divergence has a reason — a performance-critical path, a compatibility shim
+  for an older Python, or a deliberate migration in progress (new pattern being rolled out).
+- **Real bug:** divergence with no rationale, where the two variants have *different behavior* on
+  edge cases (error handling, encoding, path separators) — behavioral divergence outranks stylistic.
+
+### 13. Vendored / generated code
+- **Symptom:** any finding inside `_vendor/`, `third_party/`, `*_pb2.py`, `*.generated.py`, migrations.
+- **Why non-bug:** not this project's code to change; regenerating overwrites edits.
+- **Real bug:** none here — but a *stale vendored copy with a known CVE* is worth raising separately
+  as a dependency finding, not a code finding.
+
+---
+
+## Documentation
+
+### 14. Intentionally-terse docstring
+- **Symptom:** a one-line or missing docstring flagged.
+- **Why non-bug:** the function is a trivial, self-describing accessor, a private helper, or an
+  override whose contract is documented on the base class.
+- **Real bug:** a docstring that is **wrong** — documents parameters that no longer exist, states a
+  return type that changed, or describes behavior the body contradicts. Stale beats absent as a
+  finding: absent docs mislead nobody.
+
+---
+
+## Git history
+
+### 15. Churn from mechanical change
+- **Symptom:** a file topping the churn/risk ranking.
+- **Why non-bug:** the churn is formatting, a lint sweep, a mass rename, dependency bumps, or a
+  license-header change — high line counts, zero semantic risk.
+- **Real bug:** churn concentrated in *bug-fix* commits touching the same function repeatedly. Read
+  the commit subjects before ranking; `fix:`/`hotfix` density is the signal, not raw line count.

--- a/plugins/code-review-toolkit/scripts/analyze_history.py
+++ b/plugins/code-review-toolkit/scripts/analyze_history.py
@@ -27,6 +27,12 @@ from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from scan_common import (  # noqa: E402
+    find_project_root,
+)
+
 # Commit classification rules — first match wins.
 CLASSIFICATION_RULES: list[tuple[str, list[str]]] = [
     ("fix", ["fix", "bug", "patch", "resolve", "issue", "crash",
@@ -52,17 +58,6 @@ _SCRIPT_TIMEOUT = 300  # 5 minutes
 _MAX_DIFF_LINES_FIX = 150
 _MAX_DIFF_LINES_REFACTOR = 80
 _FUNCTION_COUNT_THRESHOLD = 500
-
-
-def find_project_root(start: Path) -> Path:
-    """Walk up to find the project root (directory containing .git)."""
-    markers = {"pyproject.toml", "setup.cfg", "setup.py", ".git"}
-    current = start if start.is_dir() else start.parent
-    while current != current.parent:
-        if any((current / m).exists() for m in markers):
-            return current
-        current = current.parent
-    return start if start.is_dir() else start.parent
 
 
 def classify_commit(message: str) -> str:

--- a/plugins/code-review-toolkit/scripts/analyze_imports.py
+++ b/plugins/code-review-toolkit/scripts/analyze_imports.py
@@ -18,8 +18,14 @@ Usage:
 import ast
 import json
 import sys
-from collections.abc import Generator
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from scan_common import (  # noqa: E402
+    discover_python_files,
+    find_project_root,
+)
 
 
 # Comprehensive stdlib module list (Python 3.10+).  Used to distinguish
@@ -71,27 +77,6 @@ def _is_stdlib(top_level_name: str) -> bool:
     if hasattr(sys, "stdlib_module_names"):
         return top_level_name in sys.stdlib_module_names
     return top_level_name in _STDLIB_TOP_LEVEL
-
-
-def discover_python_files(root: Path) -> "Generator[Path, None, None]":
-    """Yield .py files under *root*, excluding common non-source dirs."""
-    exclude = {".git", ".tox", ".venv", "venv", "__pycache__",
-               "node_modules", ".eggs", "build", "dist"}
-    if root.is_file():
-        if root.suffix == ".py":
-            yield root
-        return
-    for p in sorted(root.rglob("*.py")):
-        parts = set(p.relative_to(root).parts)
-        if parts & exclude:
-            continue
-        # Skip egg-info directories (glob pattern matching).
-        if any(
-            part.endswith(".egg-info")
-            for part in p.relative_to(root).parts
-        ):
-            continue
-        yield p
 
 
 def _resolve_relative_import(
@@ -259,17 +244,6 @@ def analyze_file(
             })
 
     return result
-
-
-def find_project_root(start: Path) -> Path:
-    """Walk upward to find project root (dir with pyproject.toml, setup.cfg, .git)."""
-    markers = {"pyproject.toml", "setup.cfg", "setup.py", ".git"}
-    current = start if start.is_dir() else start.parent
-    while current != current.parent:
-        if any((current / m).exists() for m in markers):
-            return current
-        current = current.parent
-    return start if start.is_dir() else start.parent
 
 
 def identify_project_packages(root: Path) -> set[str]:

--- a/plugins/code-review-toolkit/scripts/build_informed_briefing.py
+++ b/plugins/code-review-toolkit/scripts/build_informed_briefing.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Assemble the informed-explore briefing from the project-independent catalogs.
+
+Emits a **Markdown briefing** (to stdout) that every agent in the
+``informed-explore`` command reads before its own analysis. It seeds each agent
+with
+
+  (a) the bug-SHAPE catalog (``data/python_bug_shapes.json``) as sibling-hunt
+      templates, scoped to the shapes that agent owns,
+  (b) the false-positive taxonomy (``data/python_non_bugs.md``) to suppress, and
+  (c) the cross-cutting triage rules (guarded-twin, systemic-root,
+      behavioural-divergence-outranks-stylistic, silent-beats-loud).
+
+These are project-INDEPENDENT shapes, so one briefing applies to any Python
+codebase. If the target carries a per-project findings memory at
+``<target>/.code-review/findings.json`` (confirmed findings accumulated by prior
+runs), those are folded in as "confirm, don't re-litigate" entries so a re-run of
+the same project is genuinely informed rather than cold.
+
+That findings file uses the same schema as the ``crate-local/findings.json`` in
+the ``*-review-findings`` companion repositories, so a project's accumulated
+memory can be lifted into a findings repo without transformation.
+
+Usage:
+    python build_informed_briefing.py [path] [--agent NAME] [--max-files N]
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from scan_common import emit, parse_common_args  # noqa: E402
+
+_DATA = Path(__file__).resolve().parent.parent / "data"
+
+# Findings whose status means "already established -- confirm, don't re-derive".
+_CONFIRMED_STATUS = {"confirmed", "reported", "fixed"}
+
+# Where a reviewed project accumulates its own findings memory between runs.
+_PROJECT_MEMORY = Path(".code-review") / "findings.json"
+
+
+def _load_shapes() -> list[dict]:
+    """Load the bug-shape catalog; empty list if the data file is absent."""
+    try:
+        with (_DATA / "python_bug_shapes.json").open(encoding="utf-8") as handle:
+            return json.load(handle).get("shapes", [])
+    except (OSError, json.JSONDecodeError):
+        return []
+
+
+def _load_fp_taxonomy() -> str:
+    """Load the false-positive taxonomy markdown; empty string if absent."""
+    try:
+        return (_DATA / "python_non_bugs.md").read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def _load_project_findings(target: str) -> list[dict]:
+    """Load a target project's accumulated findings memory, if any."""
+    path = Path(target).resolve()
+    if path.is_file():
+        path = path.parent
+    try:
+        with (path / _PROJECT_MEMORY).open(encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return []
+    if isinstance(data, list):
+        findings = data
+    elif isinstance(data, dict):
+        findings = data.get("findings", [])
+    else:
+        findings = []
+    return [f for f in findings if isinstance(f, dict)]
+
+
+def _shapes_by_agent(shapes: list[dict]) -> dict[str, list[dict]]:
+    """Group shapes under the agent that owns them."""
+    grouped: dict[str, list[dict]] = {}
+    for shape in shapes:
+        grouped.setdefault(shape.get("agent", "unassigned"), []).append(shape)
+    return grouped
+
+
+def _render_shape(shape: dict) -> str:
+    """Render one bug shape as a briefing entry."""
+    lines = [
+        f"#### `{shape.get('id', '?')}` — {shape.get('title', '')}",
+        "",
+        f"- **Default severity:** {shape.get('severity', 'CONSIDER')} "
+        f"(before triage) · **grounding:** {shape.get('validation', 'unknown')}",
+        f"- **Pattern:** {shape.get('pattern', '')}",
+        f"- **Guarded twin (the fix):** {shape.get('guarded_twin', '')}",
+        f"- **Sibling hunt:** {shape.get('hunt', '')}",
+        f"- **Expected behaviour:** {shape.get('expected', '')}",
+        f"- **Surfaces as:** {shape.get('caught_as', '')}",
+    ]
+    if shape.get("differential"):
+        lines.append(f"- **Do NOT flag when:** {shape['differential']}")
+    confirmed = shape.get("confirmed_examples") or []
+    if confirmed:
+        lines.append("- **Confirmed instances:** " + "; ".join(confirmed))
+    return "\n".join(lines)
+
+
+TRIAGE_RULES = """\
+1. **Guarded twin.** Most real defects have a sibling in the same codebase that
+   already does it right. Find that twin — it is both proof the shape is a bug
+   *in this project's own judgement* and the exact fix to propose. A shape with
+   no twin anywhere may be a deliberate project-wide convention.
+2. **Systemic root over instance count.** Ten instances of one shape is one
+   finding with ten sites, not ten findings. Report the root and enumerate the
+   sites; that is what a maintainer can act on in a single change.
+3. **Silent beats loud.** A defect that raises is already visible to its
+   authors; a defect that silently produces wrong results is not. When ranking,
+   weight the silent shapes above the noisy ones even when severity ties.
+4. **Behavioural divergence outranks stylistic.** Two modules formatting
+   differently is noise. Two modules *handling the same error case differently*
+   is a finding — one of them is wrong.
+5. **Confirm, don't re-litigate.** Anything listed below as already-confirmed is
+   settled. Verify it still exists and move on; spend the run on un-found
+   siblings, not on re-deriving known results.
+6. **Cite or drop.** Every finding needs `file:line` and a concrete failure
+   scenario (inputs → wrong outcome). A finding you cannot make concrete is a
+   hypothesis; label it as one or drop it.
+"""
+
+
+def build_briefing(
+    shapes: list[dict],
+    fp_taxonomy: str,
+    project_findings: list[dict],
+    agent: str | None = None,
+) -> str:
+    """Assemble the full Markdown briefing."""
+    grouped = _shapes_by_agent(shapes)
+    if agent:
+        grouped = {agent: grouped.get(agent, [])}
+
+    parts: list[str] = [
+        "# Informed-review briefing",
+        "",
+        "Read this before your own analysis. It exists so you **confirm without "
+        "re-litigating**, **suppress known false positives**, and spend the run "
+        "hunting un-found siblings of established shapes rather than "
+        "rediscovering the basics from scratch.",
+        "",
+        "## Cross-cutting triage rules",
+        "",
+        TRIAGE_RULES,
+    ]
+
+    total = sum(len(v) for v in grouped.values())
+    parts += [
+        "## Bug-shape templates" + (f" for `{agent}`" if agent else "") + f" ({total})",
+        "",
+        "Each shape is a reusable *pattern*, not a location. For each one, hunt "
+        "this codebase for instances, then follow the sibling-hunt directive to "
+        "find the ones a cold pass would miss.",
+        "",
+    ]
+    if not total:
+        parts.append("_No shapes catalogued for this agent yet._\n")
+    for owner, owned in sorted(grouped.items()):
+        if not owned:
+            continue
+        if not agent:
+            parts.append(f"### Owned by `{owner}`")
+            parts.append("")
+        for shape in owned:
+            parts.append(_render_shape(shape))
+            parts.append("")
+
+    if project_findings:
+        confirmed = [
+            f
+            for f in project_findings
+            if str(f.get("status", "")).lower() in _CONFIRMED_STATUS
+        ]
+        parts += [
+            "## Already established in this project "
+            f"({len(confirmed)} confirmed of {len(project_findings)} recorded)",
+            "",
+            "From prior runs' accumulated memory (`.code-review/findings.json`). "
+            "Verify these still exist, then move on — do not re-derive them.",
+            "",
+        ]
+        for finding in confirmed:
+            loc = finding.get("location") or finding.get("file") or "?"
+            parts.append(
+                f"- **{finding.get('id', '?')}** [{finding.get('severity', '?')}] "
+                f"{finding.get('title', '')} — `{loc}`"
+            )
+        parts.append("")
+
+    if fp_taxonomy:
+        parts += [
+            "## Known false positives — suppress these",
+            "",
+            "If a candidate matches one of these classes, dismiss it *with the "
+            "stated reason* rather than reporting it. Each entry also states what "
+            "the REAL bug looks like, so a genuine instance is never suppressed.",
+            "",
+            fp_taxonomy.split("---", 1)[-1].strip()
+            if "---" in fp_taxonomy
+            else fp_taxonomy.strip(),
+            "",
+        ]
+
+    return "\n".join(parts) + "\n"
+
+
+def analyze(target: str, *, max_files: int = 0, agent: str | None = None) -> dict:
+    """Build the briefing for *target*. ``max_files`` is accepted for interface
+    parity with the other scripts; this script does not walk the file tree."""
+    shapes = _load_shapes()
+    fp_taxonomy = _load_fp_taxonomy()
+    project_findings = _load_project_findings(target)
+    briefing = build_briefing(shapes, fp_taxonomy, project_findings, agent)
+    return {
+        "target": target,
+        "shapes_total": len(shapes),
+        "shapes_included": (
+            len(_shapes_by_agent(shapes).get(agent, [])) if agent else len(shapes)
+        ),
+        "project_findings": len(project_findings),
+        "has_fp_taxonomy": bool(fp_taxonomy),
+        "briefing_markdown": briefing,
+    }
+
+
+def _extract_agent(argv: list[str]) -> tuple[list[str], str | None]:
+    """Pull ``--agent NAME`` out of argv, returning the remainder."""
+    rest: list[str] = []
+    agent: str | None = None
+    i = 0
+    while i < len(argv):
+        if argv[i] == "--agent" and i + 1 < len(argv):
+            agent = argv[i + 1]
+            i += 2
+        else:
+            rest.append(argv[i])
+            i += 1
+    return rest, agent
+
+
+def main() -> None:
+    try:
+        argv, agent = _extract_agent(sys.argv[1:])
+        target, max_files = parse_common_args(argv)
+        result = analyze(target, max_files=max_files, agent=agent)
+        # Markdown, not JSON: the output IS the agent briefing.
+        sys.stdout.write(result["briefing_markdown"])
+    except Exception as exc:  # noqa: BLE001 -- top-level guard
+        emit({"error": str(exc), "type": type(exc).__name__})
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/code-review-toolkit/scripts/collect_debt.py
+++ b/plugins/code-review-toolkit/scripts/collect_debt.py
@@ -12,9 +12,15 @@ import json
 import re
 import subprocess
 import sys
-from collections.abc import Generator
 from datetime import datetime, timezone
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from scan_common import (  # noqa: E402
+    discover_python_files,
+    find_project_root,
+)
 
 
 # Patterns to search for, grouped by category.
@@ -34,36 +40,6 @@ _MARKER_PATTERNS: dict[str, re.Pattern[str]] = {
 _SKIP_PATTERN = re.compile(
     r"@(?:unittest\.)?skip(?:If|Unless)?\s*\(", re.IGNORECASE
 )
-
-
-def discover_python_files(root: Path) -> Generator[Path, None, None]:
-    """Yield .py files under *root*, excluding common non-source dirs."""
-    exclude = {".git", ".tox", ".venv", "venv", "__pycache__",
-               "node_modules", ".eggs", "build", "dist"}
-    if root.is_file():
-        if root.suffix == ".py":
-            yield root
-        return
-    for p in sorted(root.rglob("*.py")):
-        parts = set(p.relative_to(root).parts)
-        if parts & exclude:
-            continue
-        if any(
-            part.endswith(".egg-info")
-            for part in p.relative_to(root).parts
-        ):
-            continue
-        yield p
-
-
-def find_project_root(start: Path) -> Path:
-    markers = {"pyproject.toml", "setup.cfg", "setup.py", ".git"}
-    current = start if start.is_dir() else start.parent
-    while current != current.parent:
-        if any((current / m).exists() for m in markers):
-            return current
-        current = current.parent
-    return start if start.is_dir() else start.parent
 
 
 def _has_git(project_root: Path) -> bool:

--- a/plugins/code-review-toolkit/scripts/correlate_tests.py
+++ b/plugins/code-review-toolkit/scripts/correlate_tests.py
@@ -11,38 +11,14 @@ Usage:
 import ast
 import json
 import sys
-from collections.abc import Generator
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-def discover_python_files(root: Path) -> Generator[Path, None, None]:
-    """Yield .py files under *root*, excluding common non-source dirs."""
-    exclude = {".git", ".tox", ".venv", "venv", "__pycache__",
-               "node_modules", ".eggs", "build", "dist"}
-    if root.is_file():
-        if root.suffix == ".py":
-            yield root
-        return
-    for p in sorted(root.rglob("*.py")):
-        parts = set(p.relative_to(root).parts)
-        if parts & exclude:
-            continue
-        if any(
-            part.endswith(".egg-info")
-            for part in p.relative_to(root).parts
-        ):
-            continue
-        yield p
-
-
-def find_project_root(start: Path) -> Path:
-    markers = {"pyproject.toml", "setup.cfg", "setup.py", ".git"}
-    current = start if start.is_dir() else start.parent
-    while current != current.parent:
-        if any((current / m).exists() for m in markers):
-            return current
-        current = current.parent
-    return start if start.is_dir() else start.parent
+from scan_common import (  # noqa: E402
+    discover_python_files,
+    find_project_root,
+)
 
 
 def classify_files(
@@ -333,6 +309,7 @@ def main() -> None:
 
     output = {
         "project_root": str(project_root),
+        "scan_root": str(scan_root),
         "files_total": files_total,
         "files_analyzed": len(all_files),
         "files_capped": max_files > 0 and files_total > max_files,

--- a/plugins/code-review-toolkit/scripts/count_types.py
+++ b/plugins/code-review-toolkit/scripts/count_types.py
@@ -13,38 +13,14 @@ import ast
 import json
 import re
 import sys
-from collections.abc import Generator
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-def discover_python_files(root: Path) -> Generator[Path, None, None]:
-    """Yield .py files under *root*, excluding common non-source dirs."""
-    exclude = {".git", ".tox", ".venv", "venv", "__pycache__",
-               "node_modules", ".eggs", "build", "dist"}
-    if root.is_file():
-        if root.suffix == ".py":
-            yield root
-        return
-    for p in sorted(root.rglob("*.py")):
-        parts = set(p.relative_to(root).parts)
-        if parts & exclude:
-            continue
-        if any(
-            part.endswith(".egg-info")
-            for part in p.relative_to(root).parts
-        ):
-            continue
-        yield p
-
-
-def find_project_root(start: Path) -> Path:
-    markers = {"pyproject.toml", "setup.cfg", "setup.py", ".git"}
-    current = start if start.is_dir() else start.parent
-    while current != current.parent:
-        if any((current / m).exists() for m in markers):
-            return current
-        current = current.parent
-    return start if start.is_dir() else start.parent
+from scan_common import (  # noqa: E402
+    discover_python_files,
+    find_project_root,
+)
 
 
 def _annotation_to_str(node: ast.AST | None) -> str | None:

--- a/plugins/code-review-toolkit/scripts/extract_test_invariants.py
+++ b/plugins/code-review-toolkit/scripts/extract_test_invariants.py
@@ -17,42 +17,17 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from scan_common import (  # noqa: E402
+    discover_python_files,
+    find_project_root,
+)
+
 
 # ---------------------------------------------------------------------------
 # Project discovery (adapted from correlate_tests.py)
 # ---------------------------------------------------------------------------
-
-_EXCLUDE_DIRS = {
-    ".git", ".tox", ".venv", "venv", "__pycache__",
-    "node_modules", ".eggs", "build", "dist",
-}
-
-
-def find_project_root(start: Path) -> Path:
-    """Walk up from *start* looking for project markers."""
-    markers = {"pyproject.toml", "setup.cfg", "setup.py", ".git"}
-    current = start if start.is_dir() else start.parent
-    while current != current.parent:
-        if any((current / m).exists() for m in markers):
-            return current
-        current = current.parent
-    return start if start.is_dir() else start.parent
-
-
-def discover_python_files(root: Path) -> list[Path]:
-    """Return .py files under *root*, excluding common non-source dirs."""
-    if root.is_file():
-        return [root] if root.suffix == ".py" else []
-    result: list[Path] = []
-    for p in sorted(root.rglob("*.py")):
-        parts = set(p.relative_to(root).parts)
-        if parts & _EXCLUDE_DIRS:
-            continue
-        if any(part.endswith(".egg-info") for part in p.relative_to(root).parts):
-            continue
-        result.append(p)
-    return result
-
 
 def classify_files(
     files: list[Path], project_root: Path
@@ -589,7 +564,10 @@ def _extract_all_test_info(
                 "behavioral_assertion_count": sum(
                     1 for a in assertions if not a.get("is_implementation_detail")
                 ),
-                "invariant_types": list({a["invariant_type"] for a in assertions}),
+                # Sorted: set iteration order varies with PYTHONHASHSEED, which
+                # would make output non-reproducible across runs and defeat
+                # cross-run deduplication (see explore's --runs option).
+                "invariant_types": sorted({a["invariant_type"] for a in assertions}),
                 "tested_function": tested_func,
             }
             all_tests.append(info)
@@ -603,7 +581,7 @@ def analyze(target: str, *, max_files: int = 0, with_git: bool = False) -> dict:
     project_root = find_project_root(target_path)
     scan_root = target_path if target_path.is_dir() else target_path.parent
 
-    all_files = discover_python_files(scan_root)
+    all_files = list(discover_python_files(scan_root))
     if max_files > 0:
         all_files = all_files[:max_files]
 

--- a/plugins/code-review-toolkit/scripts/find_dead_symbols.py
+++ b/plugins/code-review-toolkit/scripts/find_dead_symbols.py
@@ -13,38 +13,14 @@ import ast
 import json
 import re
 import sys
-from collections.abc import Generator
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-def discover_python_files(root: Path) -> Generator[Path, None, None]:
-    """Yield .py files under *root*, excluding common non-source dirs."""
-    exclude = {".git", ".tox", ".venv", "venv", "__pycache__",
-               "node_modules", ".eggs", "build", "dist"}
-    if root.is_file():
-        if root.suffix == ".py":
-            yield root
-        return
-    for p in sorted(root.rglob("*.py")):
-        parts = set(p.relative_to(root).parts)
-        if parts & exclude:
-            continue
-        if any(
-            part.endswith(".egg-info")
-            for part in p.relative_to(root).parts
-        ):
-            continue
-        yield p
-
-
-def find_project_root(start: Path) -> Path:
-    markers = {"pyproject.toml", "setup.cfg", "setup.py", ".git"}
-    current = start if start.is_dir() else start.parent
-    while current != current.parent:
-        if any((current / m).exists() for m in markers):
-            return current
-        current = current.parent
-    return start if start.is_dir() else start.parent
+from scan_common import (  # noqa: E402
+    discover_python_files,
+    find_project_root,
+)
 
 
 # Magic methods that are called implicitly by Python.

--- a/plugins/code-review-toolkit/scripts/measure_complexity.py
+++ b/plugins/code-review-toolkit/scripts/measure_complexity.py
@@ -18,39 +18,14 @@ Usage:
 import ast
 import json
 import sys
-from collections.abc import Generator
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-def discover_python_files(root: Path) -> Generator[Path, None, None]:
-    """Yield .py files under *root*, excluding common non-source dirs."""
-    exclude = {".git", ".tox", ".venv", "venv", "__pycache__",
-               "node_modules", ".eggs", "build", "dist"}
-    if root.is_file():
-        if root.suffix == ".py":
-            yield root
-        return
-    for p in sorted(root.rglob("*.py")):
-        parts = set(p.relative_to(root).parts)
-        if parts & exclude:
-            continue
-        if any(
-            part.endswith(".egg-info")
-            for part in p.relative_to(root).parts
-        ):
-            continue
-        yield p
-
-
-def find_project_root(start: Path) -> Path:
-    """Walk upward to find project root."""
-    markers = {"pyproject.toml", "setup.cfg", "setup.py", ".git"}
-    current = start if start.is_dir() else start.parent
-    while current != current.parent:
-        if any((current / m).exists() for m in markers):
-            return current
-        current = current.parent
-    return start if start.is_dir() else start.parent
+from scan_common import (  # noqa: E402
+    discover_python_files,
+    find_project_root,
+)
 
 
 class _NestingVisitor(ast.NodeVisitor):

--- a/plugins/code-review-toolkit/scripts/run_external_tools.py
+++ b/plugins/code-review-toolkit/scripts/run_external_tools.py
@@ -26,6 +26,12 @@ import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from scan_common import (  # noqa: E402
+    find_project_root,
+)
+
 _KNOWN_TOOLS = ("ruff", "mypy", "vulture", "coverage")
 
 _TOOL_TIMEOUTS = {
@@ -52,17 +58,6 @@ _RUFF_CATEGORY_BY_PREFIX: dict[str, str] = {
 # ---------------------------------------------------------------------------
 # Utility helpers
 # ---------------------------------------------------------------------------
-
-def find_project_root(start: Path) -> Path:
-    """Walk upward from *start* looking for project root markers."""
-    markers = {"pyproject.toml", "setup.cfg", "setup.py", ".git"}
-    current = start if start.is_dir() else start.parent
-    while current != current.parent:
-        if any((current / m).exists() for m in markers):
-            return current
-        current = current.parent
-    return start if start.is_dir() else start.parent
-
 
 def make_relative(filepath: str, project_root: Path) -> str:
     """Make *filepath* relative to *project_root*."""

--- a/plugins/code-review-toolkit/scripts/scan_common.py
+++ b/plugins/code-review-toolkit/scripts/scan_common.py
@@ -1,0 +1,219 @@
+"""Shared utilities for code-review-toolkit analysis scripts.
+
+Every analysis script imports from here rather than re-implementing file
+discovery, project-root detection, and CLI parsing. Before this module existed
+`find_project_root` was byte-identical in all nine scripts and
+`discover_python_files` had drifted into three divergent variants -- the exact
+decay this module prevents.
+
+Scripts add this directory to ``sys.path`` (the scripts directory is not a
+package -- there is no ``__init__.py``) and then ``import scan_common``.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import sys
+from collections.abc import Generator, Iterable, Sequence
+from pathlib import Path
+
+# Directories never worth walking into when discovering source files.
+EXCLUDE_DIRS = frozenset(
+    {
+        ".git",
+        ".tox",
+        ".venv",
+        "venv",
+        "__pycache__",
+        "node_modules",
+        ".eggs",
+        "build",
+        "dist",
+    }
+)
+
+# Markers that identify the root of a Python project.
+PROJECT_ROOT_MARKERS = frozenset({"pyproject.toml", "setup.cfg", "setup.py", ".git"})
+
+_DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+
+
+def find_project_root(start: Path) -> Path:
+    """Walk upward from *start* to find the project root.
+
+    Returns the first ancestor containing a project marker, or the starting
+    directory if no marker is found.
+    """
+    current = start if start.is_dir() else start.parent
+    while current != current.parent:
+        if any((current / m).exists() for m in PROJECT_ROOT_MARKERS):
+            return current
+        current = current.parent
+    return start if start.is_dir() else start.parent
+
+
+def _is_excluded(path: Path, root: Path) -> bool:
+    """True if *path* lives under an excluded directory relative to *root*."""
+    try:
+        parts = path.relative_to(root).parts
+    except ValueError:
+        parts = path.parts
+    if set(parts) & EXCLUDE_DIRS:
+        return True
+    return any(part.endswith(".egg-info") for part in parts)
+
+
+def discover_python_files(root: Path) -> Generator[Path, None, None]:
+    """Yield ``.py`` files under *root*, excluding common non-source dirs.
+
+    Accepts a file as well as a directory: a single ``.py`` file yields itself,
+    anything else yields nothing. Results are sorted for deterministic output.
+    """
+    if root.is_file():
+        if root.suffix == ".py":
+            yield root
+        return
+    for path in sorted(root.rglob("*.py")):
+        if _is_excluded(path, root):
+            continue
+        yield path
+
+
+def collect_python_files(root: Path, max_files: int = 0) -> tuple[list[Path], int]:
+    """Return ``(files, files_total)`` under *root*, capped at *max_files*.
+
+    ``files_total`` is the count *before* the cap, so callers can report how
+    many files were skipped. ``max_files <= 0`` means no limit.
+    """
+    all_files = list(discover_python_files(root))
+    files_total = len(all_files)
+    if max_files > 0 and files_total > max_files:
+        all_files = all_files[:max_files]
+    return all_files, files_total
+
+
+def parse_source(path: Path) -> ast.Module | None:
+    """Parse *path* into an AST, returning None on read or syntax errors.
+
+    Analysis scripts run over arbitrary third-party trees where an unparseable
+    file must never abort the whole scan.
+    """
+    try:
+        source = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    try:
+        return ast.parse(source)
+    except (SyntaxError, ValueError, RecursionError):
+        return None
+
+
+def relative_to_root(path: Path, root: Path) -> str:
+    """Return *path* relative to *root* as a string, falling back to absolute."""
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def parse_common_args(argv: Sequence[str]) -> tuple[str, int]:
+    """Parse the CLI arguments every analysis script accepts.
+
+    Recognizes a single positional target path (default ``.``) and
+    ``--max-files N``. Unknown ``--flags`` are ignored so individual scripts can
+    add their own without re-implementing this loop. A non-integer
+    ``--max-files`` exits with a JSON error rather than an unhandled traceback.
+    """
+    max_files = 0
+    positional: list[str] = []
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--max-files" and i + 1 < len(argv):
+            try:
+                max_files = int(argv[i + 1])
+            except ValueError:
+                emit({"error": f"--max-files requires an integer, got '{argv[i + 1]}'"})
+                sys.exit(2)
+            i += 2
+        elif arg.startswith("--"):
+            i += 1
+        else:
+            positional.append(arg)
+            i += 1
+    return (positional[0] if positional else "."), max_files
+
+
+def resolve_target(target: str) -> tuple[Path, Path, Path]:
+    """Resolve a target path into ``(target, project_root, scan_root)``.
+
+    ``scan_root`` is the target itself when it is a directory, otherwise the
+    project root -- so pointing a script at a single file still reports the
+    surrounding project correctly.
+    """
+    resolved = Path(target).resolve()
+    project_root = find_project_root(resolved)
+    scan_root = resolved if resolved.is_dir() else project_root
+    return resolved, project_root, scan_root
+
+
+def build_envelope(
+    project_root: Path,
+    scan_root: Path,
+    files_total: int,
+    files_analyzed: int,
+) -> dict:
+    """Build the JSON envelope every analysis script shares.
+
+    ``files_capped`` is a boolean the agents use to warn that results are
+    partial because ``--max-files`` truncated the scan.
+    """
+    return {
+        "project_root": str(project_root),
+        "scan_root": str(scan_root),
+        "files_total": files_total,
+        "files_analyzed": files_analyzed,
+        "files_capped": files_analyzed < files_total,
+    }
+
+
+def load_data(name: str) -> dict:
+    """Load a JSON file from the plugin's ``data/`` directory.
+
+    Returns an empty dict when the file is missing so a script keeps working
+    against an older plugin checkout.
+    """
+    path = _DATA_DIR / name
+    try:
+        with path.open(encoding="utf-8") as handle:
+            return json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def deduplicate_findings(findings: Iterable[dict]) -> list[dict]:
+    """Drop findings that repeat the same ``(file, line, type)`` triple.
+
+    Order is preserved so the first (usually highest-confidence) occurrence of a
+    duplicate wins.
+    """
+    seen: set[tuple] = set()
+    result: list[dict] = []
+    for finding in findings:
+        key = (
+            finding.get("file"),
+            finding.get("line"),
+            finding.get("type") or finding.get("kind"),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(finding)
+    return result
+
+
+def emit(payload: dict) -> None:
+    """Write *payload* to stdout as JSON -- the output contract for all scripts."""
+    json.dump(payload, sys.stdout, indent=2, default=str)
+    sys.stdout.write("\n")

--- a/plugins/code-review-toolkit/scripts/scan_python_pitfalls.py
+++ b/plugins/code-review-toolkit/scripts/scan_python_pitfalls.py
@@ -1,0 +1,922 @@
+#!/usr/bin/env python3
+"""Detect the correctness pitfalls catalogued in data/python_bug_shapes.json.
+
+Each check corresponds 1:1 to a shape `id` in that catalog, so a finding can be
+traced straight back to its shape (with its guarded twin, sibling-hunt directive,
+and differential). The differentials are applied here as confidence downgrades
+rather than hard filters: the script's job is high recall with an honest
+confidence signal, and the agent's job is the final call.
+
+Confidence levels:
+    high    -- the differential does not apply; this is very likely a real defect
+    medium  -- matches the shape, but a legitimate reading exists; agent must check
+    low     -- weak signal, reported only so a sibling hunt can start from it
+
+Usage:
+    python scan_python_pitfalls.py [path] [--max-files N] [--check ID[,ID...]] [--exclude PAT[,PAT...]]
+"""
+
+from __future__ import annotations
+
+import ast
+import builtins
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from scan_common import (  # noqa: E402
+    build_envelope,
+    collect_python_files,
+    emit,
+    parse_common_args,
+    parse_source,
+    relative_to_root,
+)
+
+# --------------------------------------------------------------------------
+# Reference tables
+# --------------------------------------------------------------------------
+
+# Names that make a default value mutable. `datetime.now()`-style calls are
+# evaluated once at def time, which is the same defect wearing different clothes.
+_MUTABLE_CALLS = frozenset(
+    {
+        "list",
+        "dict",
+        "set",
+        "bytearray",
+        "collections",
+        "Counter",
+        "defaultdict",
+        "OrderedDict",
+        "deque",
+    }
+)
+_EVALUATED_ONCE_CALLS = frozenset(
+    {"now", "today", "utcnow", "time", "uuid4", "monotonic"}
+)
+
+# Calls that block the thread -- fatal inside `async def`.
+_BLOCKING_CALLS = frozenset(
+    {
+        "time.sleep",
+        "os.system",
+        "subprocess.run",
+        "subprocess.call",
+        "subprocess.check_call",
+        "subprocess.check_output",
+        "urllib.request.urlopen",
+        "requests.get",
+        "requests.post",
+        "requests.put",
+        "requests.delete",
+        "requests.patch",
+        "requests.head",
+        "requests.request",
+        "socket.create_connection",
+    }
+)
+
+# Methods that mutate the receiver in place.
+_MUTATING_METHODS = frozenset(
+    {
+        "append",
+        "extend",
+        "insert",
+        "remove",
+        "pop",
+        "clear",
+        "update",
+        "add",
+        "discard",
+        "sort",
+        "setdefault",
+        "popitem",
+    }
+)
+
+# Calls that produce a safe snapshot of a container.
+_SNAPSHOT_CALLS = frozenset(
+    {
+        "list",
+        "tuple",
+        "set",
+        "dict",
+        "sorted",
+        "frozenset",
+        "copy",
+        "deepcopy",
+        "reversed",
+        "items",
+        "keys",
+        "values",
+    }
+)
+
+# Decorators that make a class derive __eq__/__hash__ for you.
+_DATACLASS_DECORATORS = frozenset(
+    {"dataclass", "attrs", "define", "frozen", "total_ordering"}
+)
+
+
+def _exception_ancestors() -> dict[str, set[str]]:
+    """Map each builtin exception name to the set of its ancestor names.
+
+    Derived from the running interpreter, so it is always correct for the Python
+    in use rather than a hand-maintained table that drifts.
+    """
+    table: dict[str, set[str]] = {}
+    for name in dir(builtins):
+        obj = getattr(builtins, name)
+        if isinstance(obj, type) and issubclass(obj, BaseException):
+            table[name] = {
+                base.__name__
+                for base in obj.__mro__[1:]
+                if isinstance(base, type) and issubclass(base, BaseException)
+            }
+    return table
+
+
+_EXC_ANCESTORS = _exception_ancestors()
+
+
+# --------------------------------------------------------------------------
+# AST helpers
+# --------------------------------------------------------------------------
+
+
+def _dotted_name(node: ast.AST) -> str:
+    """Render an attribute/name chain as a dotted string ('a.b.c'), else ''."""
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+        return ".".join(reversed(parts))
+    return ""
+
+
+def _call_name(node: ast.Call) -> str:
+    """Best-effort dotted name of what a Call invokes."""
+    return _dotted_name(node.func)
+
+
+def _names_used(node: ast.AST) -> set[str]:
+    """All bare Name identifiers loaded anywhere under *node*."""
+    return {n.id for n in ast.walk(node) if isinstance(n, ast.Name)}
+
+
+def _is_snapshot(node: ast.AST) -> bool:
+    """True if *node* evaluates to a copy rather than the live container."""
+    if isinstance(node, ast.Call):
+        name = _call_name(node)
+        return bool(name) and name.split(".")[-1] in _SNAPSHOT_CALLS
+    # d[:] / lst[:] produce a copy.
+    return isinstance(node, ast.Subscript) and isinstance(node.slice, ast.Slice)
+
+
+def _decorator_names(
+    node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef,
+) -> set[str]:
+    """Flattened decorator names, including the attribute tail."""
+    found: set[str] = set()
+    for dec in node.decorator_list:
+        target = dec.func if isinstance(dec, ast.Call) else dec
+        name = _dotted_name(target)
+        if name:
+            found.add(name)
+            found.add(name.split(".")[-1])
+    return found
+
+
+def _mutates(name: str, body: list[ast.stmt]) -> bool:
+    """True if *name* is mutated (method call, item/attr assignment, del) in *body*."""
+    for stmt in body:
+        for node in ast.walk(stmt):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr in _MUTATING_METHODS
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == name
+            ):
+                return True
+            if isinstance(node, (ast.Assign, ast.AugAssign, ast.AnnAssign)):
+                targets = (
+                    node.targets if isinstance(node, ast.Assign) else [node.target]
+                )
+                for tgt in targets:
+                    if isinstance(tgt, ast.Subscript) and isinstance(
+                        tgt.value, ast.Name
+                    ):
+                        if tgt.value.id == name:
+                            return True
+            if isinstance(node, ast.Delete):
+                for tgt in node.targets:
+                    if isinstance(tgt, ast.Subscript) and isinstance(
+                        tgt.value, ast.Name
+                    ):
+                        if tgt.value.id == name:
+                            return True
+    return False
+
+
+def _walk_same_scope(node: ast.AST):
+    """Yield descendants of *node* without entering a nested function scope.
+
+    ``ast.walk`` descends unconditionally, so a `return` inside a nested `def`
+    would otherwise be attributed to the enclosing construct.
+    """
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            continue
+        yield child
+        yield from _walk_same_scope(child)
+
+
+def _returns(name: str, body: list[ast.stmt]) -> bool:
+    """True if *name* is returned or yielded from *body*."""
+    for stmt in body:
+        for node in ast.walk(stmt):
+            if isinstance(node, (ast.Return, ast.Yield)) and node.value is not None:
+                if name in _names_used(node.value):
+                    return True
+    return False
+
+
+def _finding(
+    shape: str,
+    severity: str,
+    confidence: str,
+    node: ast.AST,
+    message: str,
+    detail: str = "",
+) -> dict:
+    """Build one finding keyed to a bug-shape id."""
+    return {
+        "shape": shape,
+        "type": shape,
+        "severity": severity,
+        "confidence": confidence,
+        "line": getattr(node, "lineno", 0),
+        "column": getattr(node, "col_offset", 0),
+        "message": message,
+        "detail": detail,
+    }
+
+
+# --------------------------------------------------------------------------
+# Checks -- one per bug shape
+# --------------------------------------------------------------------------
+
+
+def _check_mutable_default(tree: ast.AST) -> list[dict]:
+    out: list[dict] = []
+    for fn in ast.walk(tree):
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        args = fn.args
+        pairs = list(
+            zip(
+                args.args[-len(args.defaults) :] if args.defaults else [], args.defaults
+            )
+        )
+        pairs += [
+            (a, d) for a, d in zip(args.kwonlyargs, args.kw_defaults) if d is not None
+        ]
+        for arg, default in pairs:
+            kind = ""
+            if isinstance(default, (ast.List, ast.Dict, ast.Set)):
+                kind = type(default).__name__.lower()
+            elif isinstance(default, ast.Call):
+                name = _call_name(default)
+                tail = name.split(".")[-1] if name else ""
+                if tail in _MUTABLE_CALLS:
+                    kind = f"{tail}()"
+                elif tail in _EVALUATED_ONCE_CALLS:
+                    kind = f"{name}()"
+            if not kind:
+                continue
+            mutated = _mutates(arg.arg, fn.body)
+            returned = _returns(arg.arg, fn.body)
+            if mutated:
+                conf, why = "high", "the parameter is mutated in the body"
+            elif returned:
+                conf, why = "high", "the shared object is returned to callers"
+            else:
+                conf, why = (
+                    "medium",
+                    "no mutation seen; may be read-only (see differential)",
+                )
+            out.append(
+                _finding(
+                    "mutable-default-argument",
+                    "FIX",
+                    conf,
+                    default,
+                    f"{fn.name}(): default for '{arg.arg}' is {kind}, evaluated once at "
+                    f"def time and shared by every call",
+                    why,
+                )
+            )
+    return out
+
+
+def _check_late_binding_closure(tree: ast.AST) -> list[dict]:
+    out: list[dict] = []
+    for loop in ast.walk(tree):
+        if not isinstance(loop, (ast.For, ast.AsyncFor, ast.While)):
+            continue
+        if isinstance(loop, ast.While):
+            loop_vars: set[str] = set()
+        else:
+            loop_vars = {n.id for n in ast.walk(loop.target) if isinstance(n, ast.Name)}
+        if not loop_vars:
+            continue
+        for node in ast.walk(loop):
+            if not isinstance(
+                node, (ast.Lambda, ast.FunctionDef, ast.AsyncFunctionDef)
+            ):
+                continue
+            body = node.body if isinstance(node, ast.Lambda) else node
+            captured = (
+                _names_used(body if isinstance(body, ast.AST) else node) & loop_vars
+            )
+            if not captured:
+                continue
+            # Default-argument binding (lambda i=i: ...) is the documented fix.
+            bound = (
+                {a.arg for a in (node.args.args if hasattr(node, "args") else [])}
+                if isinstance(node, (ast.Lambda, ast.FunctionDef, ast.AsyncFunctionDef))
+                else set()
+            )
+            if captured <= bound:
+                continue
+            out.append(
+                _finding(
+                    "late-binding-closure-in-loop",
+                    "FIX",
+                    "medium",
+                    node,
+                    f"closure created in a loop captures {sorted(captured)} by reference; "
+                    f"every instance will see the final value",
+                    "safe if the callable is consumed within the same iteration -- "
+                    "check whether it escapes the loop",
+                )
+            )
+    return out
+
+
+def _check_except_ordering(tree: ast.AST) -> list[dict]:
+    out: list[dict] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Try):
+            continue
+        seen: list[tuple[str, ast.ExceptHandler]] = []
+        for handler in node.handlers:
+            names: list[str] = []
+            if isinstance(handler.type, ast.Name):
+                names = [handler.type.id]
+            elif isinstance(handler.type, ast.Tuple):
+                names = [e.id for e in handler.type.elts if isinstance(e, ast.Name)]
+            for name in names:
+                ancestors = _EXC_ANCESTORS.get(name)
+                if ancestors is None:
+                    continue  # user-defined; hierarchy unknown statically
+                for earlier, _ in seen:
+                    if earlier in ancestors:
+                        out.append(
+                            _finding(
+                                "except-clause-ordering-unreachable",
+                                "FIX",
+                                "high",
+                                handler,
+                                f"`except {name}` is unreachable: `except {earlier}` above "
+                                f"already catches it ({name} subclasses {earlier})",
+                                "clauses are tested top-to-bottom; order most-specific first",
+                            )
+                        )
+                        break
+            for name in names:
+                seen.append((name, handler))
+    return out
+
+
+def _check_return_in_finally(tree: ast.AST) -> list[dict]:
+    out: list[dict] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Try) or not node.finalbody:
+            continue
+        for stmt in node.finalbody:
+            # Control flow belonging to THIS finally only -- a return inside a
+            # nested def belongs to that function, not to the finally.
+            candidates = [stmt, *_walk_same_scope(stmt)]
+            if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+                candidates = []
+            for inner in candidates:
+                kw = None
+                if isinstance(inner, ast.Return):
+                    kw = "return"
+                elif isinstance(inner, ast.Break):
+                    kw = "break"
+                elif isinstance(inner, ast.Continue):
+                    kw = "continue"
+                if kw:
+                    out.append(
+                        _finding(
+                            "return-or-break-in-finally",
+                            "FIX",
+                            "high",
+                            inner,
+                            f"`{kw}` inside `finally` discards any exception propagating "
+                            f"through the try block",
+                            "the caller sees a normal return instead of the error",
+                        )
+                    )
+    return out
+
+
+def _check_eq_without_hash(tree: ast.AST) -> list[dict]:
+    out: list[dict] = []
+    for cls in ast.walk(tree):
+        if not isinstance(cls, ast.ClassDef):
+            continue
+        decorators = _decorator_names(cls)
+        if decorators & _DATACLASS_DECORATORS:
+            continue  # eq/hash are derived
+        methods = {
+            m.name
+            for m in cls.body
+            if isinstance(m, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        # An explicit `__hash__ = None` is a deliberate opt-out.
+        explicit = {
+            t.id
+            for stmt in cls.body
+            if isinstance(stmt, ast.Assign)
+            for t in stmt.targets
+            if isinstance(t, ast.Name)
+        }
+        if (
+            "__eq__" in methods
+            and "__hash__" not in methods
+            and "__hash__" not in explicit
+        ):
+            out.append(
+                _finding(
+                    "eq-without-hash",
+                    "CONSIDER",
+                    "medium",
+                    cls,
+                    f"class {cls.name} defines __eq__ but not __hash__; instances become "
+                    f"unhashable (Python sets __hash__ = None)",
+                    "only a problem if instances are used in a set or as dict keys -- check",
+                )
+            )
+    return out
+
+
+def _check_mutation_during_iteration(tree: ast.AST) -> list[dict]:
+    out: list[dict] = []
+    for loop in ast.walk(tree):
+        if not isinstance(loop, (ast.For, ast.AsyncFor)):
+            continue
+        iterated = loop.iter
+        # `for k in d.items()` etc. still iterates d -- unwrap one attribute call.
+        if isinstance(iterated, ast.Call) and isinstance(iterated.func, ast.Attribute):
+            if iterated.func.attr in {"items", "keys", "values"}:
+                iterated = iterated.func.value
+            elif _is_snapshot(iterated):
+                continue
+        elif _is_snapshot(iterated):
+            continue
+        if not isinstance(iterated, ast.Name):
+            continue
+        name = iterated.id
+        if _mutates(name, loop.body):
+            out.append(
+                _finding(
+                    "mutation-during-iteration",
+                    "FIX",
+                    "high",
+                    loop,
+                    f"'{name}' is mutated while being iterated",
+                    "dict/set raise RuntimeError; LISTS SILENTLY SKIP elements as indices "
+                    "shift -- iterate over a snapshot such as list(...)",
+                )
+            )
+    return out
+
+
+def _check_fire_and_forget_task(tree: ast.AST) -> list[dict]:
+    out: list[dict] = []
+    for node in ast.walk(tree):
+        # A bare expression statement -- the return value goes nowhere.
+        if not isinstance(node, ast.Expr) or not isinstance(node.value, ast.Call):
+            continue
+        name = _call_name(node.value)
+        tail = name.split(".")[-1] if name else ""
+        if tail in {"create_task", "ensure_future"} and (
+            "asyncio" in name or "loop" in name or tail == "create_task"
+        ):
+            out.append(
+                _finding(
+                    "asyncio-fire-and-forget-task",
+                    "FIX",
+                    "high",
+                    node,
+                    f"{name}(...) result is discarded; the event loop keeps only a weak "
+                    f"reference, so the task may be garbage-collected before it finishes",
+                    "retain it in a set with add_done_callback(discard), or await it",
+                )
+            )
+    return out
+
+
+def _check_blocking_in_async(tree: ast.AST) -> list[dict]:
+    out: list[dict] = []
+    for fn in ast.walk(tree):
+        if not isinstance(fn, ast.AsyncFunctionDef):
+            continue
+        for node in ast.walk(fn):
+            # Do not descend into nested synchronous defs.
+            if isinstance(node, ast.FunctionDef) and node is not fn:
+                continue
+            if not isinstance(node, ast.Call):
+                continue
+            name = _call_name(node)
+            if name in _BLOCKING_CALLS:
+                out.append(
+                    _finding(
+                        "blocking-call-in-async-function",
+                        "FIX",
+                        "high",
+                        node,
+                        f"blocking call {name}(...) inside async def {fn.name}() stalls the "
+                        f"entire event loop",
+                        "use the async equivalent, or await asyncio.to_thread(...)",
+                    )
+                )
+    return out
+
+
+def _check_unawaited_coroutine(tree: ast.AST) -> list[dict]:
+    """Intra-file only: a coroutine defined here, called here, never awaited."""
+    out: list[dict] = []
+    async_names = {
+        n.name for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef)
+    }
+    if not async_names:
+        return out
+    awaited: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Await) and isinstance(node.value, ast.Call):
+            awaited.add(id(node.value))
+        # gather/wait/create_task consume the coroutine object legitimately.
+        if isinstance(node, ast.Call):
+            name = _call_name(node)
+            tail = name.split(".")[-1] if name else ""
+            if tail in {
+                "gather",
+                "wait",
+                "create_task",
+                "ensure_future",
+                "run",
+                "wait_for",
+            }:
+                for arg in node.args:
+                    if isinstance(arg, ast.Call):
+                        awaited.add(id(arg))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Expr) or not isinstance(node.value, ast.Call):
+            continue
+        call = node.value
+        if id(call) in awaited:
+            continue
+        name = _call_name(call)
+        tail = name.split(".")[-1] if name else ""
+        if tail in async_names:
+            out.append(
+                _finding(
+                    "unawaited-coroutine",
+                    "FIX",
+                    "high",
+                    call,
+                    f"coroutine {tail}() is called without await; the body never runs",
+                    "an un-awaited coroutine object is truthy, so guards silently take the "
+                    "wrong branch",
+                )
+            )
+    return out
+
+
+def _check_lru_cache_on_method(tree: ast.AST) -> list[dict]:
+    out: list[dict] = []
+    for cls in ast.walk(tree):
+        if not isinstance(cls, ast.ClassDef):
+            continue
+        for fn in cls.body:
+            if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            decorators = _decorator_names(fn)
+            if not (decorators & {"lru_cache", "cache"}):
+                continue
+            first = fn.args.args[0].arg if fn.args.args else ""
+            if first not in {"self", "cls"}:
+                continue
+            out.append(
+                _finding(
+                    "lru-cache-on-method",
+                    "CONSIDER",
+                    "high",
+                    fn,
+                    f"{cls.name}.{fn.name}() is cached on the CLASS with '{first}' in the key, "
+                    f"so every instance ever passed is retained for the process lifetime",
+                    "use cached_property or a per-instance cache; harmless for singletons",
+                )
+            )
+    return out
+
+
+def _check_class_level_mutable(tree: ast.AST) -> list[dict]:
+    out: list[dict] = []
+    for cls in ast.walk(tree):
+        if not isinstance(cls, ast.ClassDef):
+            continue
+        if _decorator_names(cls) & _DATACLASS_DECORATORS:
+            continue
+        for stmt in cls.body:
+            targets: list[ast.expr] = []
+            value: ast.expr | None = None
+            if isinstance(stmt, ast.Assign):
+                targets, value = stmt.targets, stmt.value
+            elif isinstance(stmt, ast.AnnAssign) and stmt.value is not None:
+                targets, value = [stmt.target], stmt.value
+            if value is None or not isinstance(value, (ast.List, ast.Dict, ast.Set)):
+                continue
+            for tgt in targets:
+                if not isinstance(tgt, ast.Name):
+                    continue
+                # ALL_CAPS reads as a constant; downgrade rather than drop.
+                conf = "medium" if tgt.id.isupper() else "high"
+                out.append(
+                    _finding(
+                        "class-level-mutable-attribute",
+                        "FIX",
+                        conf,
+                        stmt,
+                        f"{cls.name}.{tgt.id} is a mutable class attribute shared by every "
+                        f"instance",
+                        "initialize in __init__ (or use field(default_factory=...)); "
+                        "acceptable only if never mutated",
+                    )
+                )
+    return out
+
+
+def _check_bare_except(tree: ast.AST) -> list[dict]:
+    out: list[dict] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ExceptHandler):
+            continue
+        is_bare = node.type is None
+        is_base = isinstance(node.type, ast.Name) and node.type.id == "BaseException"
+        if not (is_bare or is_base):
+            continue
+        # A handler that re-raises is a legitimate boundary.
+        if any(isinstance(n, ast.Raise) for n in ast.walk(node)):
+            continue
+        # Capturing the exception for the caller to re-raise (the standard
+        # thread/worker-body pattern) preserves control flow -- observed in real
+        # code, so downgrade rather than drop.
+        captured = bool(node.name) and any(
+            isinstance(n, ast.Name) and n.id == node.name
+            for stmt in node.body
+            for n in ast.walk(stmt)
+        )
+        label = "except:" if is_bare else "except BaseException:"
+        if captured:
+            conf = "medium"
+            detail = (
+                f"the exception is captured as '{node.name}' -- legitimate if the caller "
+                f"re-raises it (thread/worker boundary); a real bug if it is only logged"
+            )
+        else:
+            conf = "high"
+            detail = "use `except Exception:` so Ctrl-C and sys.exit() still work"
+        out.append(
+            _finding(
+                "bare-except-swallows-control-flow",
+                "FIX",
+                conf,
+                node,
+                f"`{label}` without re-raise also swallows KeyboardInterrupt and SystemExit",
+                detail,
+            )
+        )
+    return out
+
+
+def _check_exception_in_del(tree: ast.AST) -> list[dict]:
+    out: list[dict] = []
+    for fn in ast.walk(tree):
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if fn.name != "__del__":
+            continue
+        guarded = any(isinstance(n, ast.Try) for n in fn.body)
+        if guarded:
+            continue
+        risky = [n for n in ast.walk(fn) if isinstance(n, ast.Call) and _call_name(n)]
+        if not risky:
+            continue
+        out.append(
+            _finding(
+                "exception-in-del-or-finalizer",
+                "CONSIDER",
+                "medium",
+                fn,
+                "__del__ performs calls without a try/except; an exception here is "
+                "printed and ignored, silently skipping the rest of the finalizer",
+                "prefer weakref.finalize or an explicit close(); module globals may "
+                "already be None at interpreter shutdown",
+            )
+        )
+    return out
+
+
+def _check_is_literal(tree: ast.AST) -> list[dict]:
+    out: list[dict] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Compare):
+            continue
+        for op, comparator in zip(node.ops, node.comparators):
+            if not isinstance(op, (ast.Is, ast.IsNot)):
+                continue
+            for side in (node.left, comparator):
+                if not isinstance(side, ast.Constant):
+                    continue
+                if side.value is None or side.value is True or side.value is False:
+                    continue
+                if side.value is Ellipsis:
+                    continue
+                out.append(
+                    _finding(
+                        "is-comparison-with-literal",
+                        "CONSIDER",
+                        "high",
+                        node,
+                        f"`is` compared against the literal {side.value!r}; identity holds "
+                        f"only by interning accident",
+                        "use == for value comparison; keep `is` for None/True/False/sentinels",
+                    )
+                )
+    return out
+
+
+_CHECKS = {
+    "mutable-default-argument": _check_mutable_default,
+    "late-binding-closure-in-loop": _check_late_binding_closure,
+    "except-clause-ordering-unreachable": _check_except_ordering,
+    "return-or-break-in-finally": _check_return_in_finally,
+    "eq-without-hash": _check_eq_without_hash,
+    "mutation-during-iteration": _check_mutation_during_iteration,
+    "asyncio-fire-and-forget-task": _check_fire_and_forget_task,
+    "blocking-call-in-async-function": _check_blocking_in_async,
+    "unawaited-coroutine": _check_unawaited_coroutine,
+    "lru-cache-on-method": _check_lru_cache_on_method,
+    "class-level-mutable-attribute": _check_class_level_mutable,
+    "bare-except-swallows-control-flow": _check_bare_except,
+    "exception-in-del-or-finalizer": _check_exception_in_del,
+    "is-comparison-with-literal": _check_is_literal,
+}
+
+
+def analyze_file(
+    path: Path, project_root: Path, checks: list[str] | None = None
+) -> list[dict]:
+    """Run the selected checks over one file. Unparseable files yield nothing."""
+    tree = parse_source(path)
+    if tree is None:
+        return []
+    selected = checks or list(_CHECKS)
+    findings: list[dict] = []
+    rel = relative_to_root(path, project_root)
+    for name in selected:
+        check = _CHECKS.get(name)
+        if check is None:
+            continue
+        for finding in check(tree):
+            finding["file"] = rel
+            findings.append(finding)
+    return findings
+
+
+def analyze(
+    target: str,
+    *,
+    max_files: int = 0,
+    checks: list[str] | None = None,
+    exclude: list[str] | None = None,
+) -> dict:
+    """Scan *target* for catalogued Python pitfalls.
+
+    ``exclude`` drops files whose project-relative path contains any of the given
+    substrings. Real-world runs show generated content (report artifacts, golden
+    fixtures, vendored trees) is the dominant false-positive source, and it is
+    project-specific enough that it cannot be hardcoded -- hence the option, plus
+    the ``by_directory`` breakdown below so such clustering is visible at a glance.
+    """
+    resolved = Path(target).resolve()
+    from scan_common import find_project_root
+
+    project_root = find_project_root(resolved)
+    # A file target scans exactly that file. (Several sibling scripts instead
+    # fall back to the project root here, which silently turns "scan this file"
+    # into "scan everything" -- a trap worth not reproducing. discover_python_files
+    # handles a file path directly, so no special-casing is needed.)
+    scan_root = resolved
+    files, files_total = collect_python_files(scan_root, max_files)
+
+    findings: list[dict] = []
+    for path in files:
+        rel = relative_to_root(path, project_root)
+        if exclude and any(pattern in rel for pattern in exclude):
+            continue
+        findings.extend(analyze_file(path, project_root, checks))
+
+    # Deterministic ordering -- see explore's --runs cross-run deduplication.
+    findings.sort(key=lambda f: (f["file"], f["line"], f["shape"]))
+
+    by_shape: dict[str, int] = {}
+    by_severity: dict[str, int] = {}
+    by_confidence: dict[str, int] = {}
+    by_directory: dict[str, int] = {}
+    for finding in findings:
+        by_shape[finding["shape"]] = by_shape.get(finding["shape"], 0) + 1
+        by_severity[finding["severity"]] = by_severity.get(finding["severity"], 0) + 1
+        by_confidence[finding["confidence"]] = (
+            by_confidence.get(finding["confidence"], 0) + 1
+        )
+        top = finding["file"].split("/")[0] if "/" in finding["file"] else "."
+        by_directory[top] = by_directory.get(top, 0) + 1
+
+    result = build_envelope(project_root, scan_root, files_total, len(files))
+    result["summary"] = {
+        "total_findings": len(findings),
+        "by_shape": dict(sorted(by_shape.items())),
+        "by_severity": dict(sorted(by_severity.items())),
+        "by_confidence": dict(sorted(by_confidence.items())),
+        # Sorted by count: a single directory dominating usually means generated
+        # content, not a real defect cluster. Triage the directory, not each hit.
+        "by_directory": dict(
+            sorted(by_directory.items(), key=lambda kv: (-kv[1], kv[0]))
+        ),
+        "checks_run": sorted(checks or _CHECKS),
+        "excluded_patterns": sorted(exclude or []),
+    }
+    result["findings"] = findings
+    return result
+
+
+def _extract_options(
+    argv: list[str],
+) -> tuple[list[str], list[str] | None, list[str] | None]:
+    """Pull ``--check`` and ``--exclude`` out of argv, returning the remainder."""
+    rest: list[str] = []
+    checks: list[str] | None = None
+    exclude: list[str] | None = None
+    i = 0
+    while i < len(argv):
+        if argv[i] == "--check" and i + 1 < len(argv):
+            checks = [c.strip() for c in argv[i + 1].split(",") if c.strip()]
+            i += 2
+        elif argv[i] == "--exclude" and i + 1 < len(argv):
+            exclude = [p.strip() for p in argv[i + 1].split(",") if p.strip()]
+            i += 2
+        else:
+            rest.append(argv[i])
+            i += 1
+    return rest, checks, exclude
+
+
+def main() -> None:
+    argv, checks, exclude = _extract_options(sys.argv[1:])
+    target, max_files = parse_common_args(argv)
+    if checks:
+        unknown = [c for c in checks if c not in _CHECKS]
+        if unknown:
+            emit(
+                {
+                    "error": f"unknown check(s): {', '.join(unknown)}",
+                    "available": sorted(_CHECKS),
+                }
+            )
+            sys.exit(2)
+    emit(analyze(target, max_files=max_files, checks=checks, exclude=exclude))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_build_informed_briefing.py
+++ b/tests/test_build_informed_briefing.py
@@ -1,0 +1,222 @@
+"""Tests for build_informed_briefing.py -- the informed-explore briefing."""
+
+import json
+import unittest
+
+from helpers import TempProject, import_script
+
+mod = import_script("build_informed_briefing")
+
+
+class TestCatalogLoading(unittest.TestCase):
+    """The shipped data files load and are well-formed."""
+
+    def test_shapes_load(self):
+        shapes = mod._load_shapes()
+        self.assertGreater(len(shapes), 0)
+
+    def test_every_shape_has_required_fields(self):
+        required = {
+            "id",
+            "title",
+            "agent",
+            "severity",
+            "pattern",
+            "guarded_twin",
+            "hunt",
+            "expected",
+            "caught_as",
+            "validation",
+        }
+        for shape in mod._load_shapes():
+            self.assertTrue(
+                required <= set(shape),
+                f"{shape.get('id')} missing {required - set(shape)}",
+            )
+
+    def test_shape_ids_are_unique(self):
+        ids = [s["id"] for s in mod._load_shapes()]
+        self.assertEqual(len(ids), len(set(ids)))
+
+    def test_severities_are_valid(self):
+        for shape in mod._load_shapes():
+            self.assertIn(
+                shape["severity"], {"FIX", "CONSIDER", "POLICY", "ACCEPTABLE"}
+            )
+
+    def test_fp_taxonomy_loads(self):
+        self.assertIn("false-positive", mod._load_fp_taxonomy().lower())
+
+
+class TestGrouping(unittest.TestCase):
+    """Shapes group under their owning agent."""
+
+    def test_groups_by_agent(self):
+        grouped = mod._shapes_by_agent(
+            [
+                {"id": "a", "agent": "x"},
+                {"id": "b", "agent": "x"},
+                {"id": "c", "agent": "y"},
+            ]
+        )
+        self.assertEqual(len(grouped["x"]), 2)
+        self.assertEqual(len(grouped["y"]), 1)
+
+    def test_missing_agent_becomes_unassigned(self):
+        grouped = mod._shapes_by_agent([{"id": "a"}])
+        self.assertIn("unassigned", grouped)
+
+
+class TestBuildBriefing(unittest.TestCase):
+    """The briefing includes rules, shapes, and the FP taxonomy."""
+
+    def _shape(self, **over):
+        base = {
+            "id": "demo-shape",
+            "title": "Demo",
+            "agent": "silent-failure-hunter",
+            "severity": "FIX",
+            "pattern": "P",
+            "guarded_twin": "T",
+            "hunt": "H",
+            "expected": "E",
+            "caught_as": "C",
+            "validation": "documented",
+        }
+        base.update(over)
+        return base
+
+    def test_includes_triage_rules(self):
+        out = mod.build_briefing([], "", [])
+        self.assertIn("Guarded twin", out)
+        self.assertIn("Cite or drop", out)
+
+    def test_includes_shape_fields(self):
+        out = mod.build_briefing([self._shape()], "", [])
+        for token in (
+            "demo-shape",
+            "Guarded twin (the fix)",
+            "Sibling hunt",
+            "Surfaces as",
+        ):
+            self.assertIn(token, out)
+
+    def test_agent_filter_scopes_shapes(self):
+        shapes = [self._shape(), self._shape(id="other", agent="dead-code-finder")]
+        out = mod.build_briefing(shapes, "", [], agent="silent-failure-hunter")
+        self.assertIn("demo-shape", out)
+        self.assertNotIn("other", out)
+
+    def test_unknown_agent_yields_empty_notice(self):
+        out = mod.build_briefing([self._shape()], "", [], agent="nope")
+        self.assertIn("No shapes catalogued", out)
+
+    def test_differential_rendered_as_do_not_flag(self):
+        out = mod.build_briefing(
+            [self._shape(differential="only when mutated")], "", []
+        )
+        self.assertIn("Do NOT flag when", out)
+
+    def test_confirmed_examples_rendered(self):
+        out = mod.build_briefing(
+            [self._shape(confirmed_examples=["PROJ-1 (a.py:1)"])], "", []
+        )
+        self.assertIn("PROJ-1", out)
+
+    def test_fp_taxonomy_appended(self):
+        out = mod.build_briefing([], "# T\nintro\n---\n### 1. Thing\nbody", [])
+        self.assertIn("Known false positives", out)
+        self.assertIn("Thing", out)
+
+    def test_no_findings_section_without_memory(self):
+        self.assertNotIn("Already established", mod.build_briefing([], "", []))
+
+
+class TestProjectMemory(unittest.TestCase):
+    """Prior-run findings are folded in as confirm-don't-relitigate entries."""
+
+    MEMORY = {
+        "findings": [
+            {
+                "id": "CRT-0001",
+                "severity": "FIX",
+                "title": "Mutable default",
+                "location": "a.py:1",
+                "status": "confirmed",
+            },
+            {
+                "id": "CRT-0002",
+                "severity": "FIX",
+                "title": "Unproven idea",
+                "location": "b.py:2",
+                "status": "candidate",
+            },
+        ]
+    }
+
+    def test_loads_memory_file(self):
+        with TempProject(
+            {".code-review/findings.json": json.dumps(self.MEMORY)}
+        ) as root:
+            self.assertEqual(len(mod._load_project_findings(str(root))), 2)
+
+    def test_only_confirmed_are_listed(self):
+        out = mod.build_briefing([], "", self.MEMORY["findings"])
+        self.assertIn("CRT-0001", out)
+        self.assertNotIn("CRT-0002", out)
+        self.assertIn("1 confirmed of 2 recorded", out)
+
+    def test_missing_memory_is_empty(self):
+        with TempProject({"mod.py": ""}) as root:
+            self.assertEqual(mod._load_project_findings(str(root)), [])
+
+    def test_malformed_memory_is_empty_not_fatal(self):
+        with TempProject({".code-review/findings.json": "{not json"}) as root:
+            self.assertEqual(mod._load_project_findings(str(root)), [])
+
+    def test_bare_list_schema_accepted(self):
+        payload = json.dumps([{"id": "X", "status": "confirmed", "title": "t"}])
+        with TempProject({".code-review/findings.json": payload}) as root:
+            self.assertEqual(len(mod._load_project_findings(str(root))), 1)
+
+    def test_file_target_resolves_to_its_directory(self):
+        with TempProject(
+            {"pkg.py": "x=1", ".code-review/findings.json": json.dumps(self.MEMORY)}
+        ) as root:
+            found = mod._load_project_findings(str(root / "pkg.py"))
+            self.assertEqual(len(found), 2)
+
+
+class TestAnalyze(unittest.TestCase):
+    """The analyze() entry point reports what went into the briefing."""
+
+    def test_returns_counts_and_markdown(self):
+        with TempProject({"m.py": ""}) as root:
+            result = mod.analyze(str(root))
+        self.assertGreater(result["shapes_total"], 0)
+        self.assertTrue(result["has_fp_taxonomy"])
+        self.assertIn("Informed-review briefing", result["briefing_markdown"])
+
+    def test_agent_filter_reduces_included_count(self):
+        with TempProject({"m.py": ""}) as root:
+            everything = mod.analyze(str(root))
+            scoped = mod.analyze(str(root), agent="silent-failure-hunter")
+        self.assertLessEqual(scoped["shapes_included"], everything["shapes_total"])
+
+
+class TestArgExtraction(unittest.TestCase):
+    """--agent is stripped before the shared arg parser sees argv."""
+
+    def test_extracts_agent(self):
+        rest, agent = mod._extract_agent(["path", "--agent", "x", "--max-files", "5"])
+        self.assertEqual(agent, "x")
+        self.assertEqual(rest, ["path", "--max-files", "5"])
+
+    def test_absent_agent_is_none(self):
+        rest, agent = mod._extract_agent(["path"])
+        self.assertIsNone(agent)
+        self.assertEqual(rest, ["path"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scan_common.py
+++ b/tests/test_scan_common.py
@@ -1,0 +1,243 @@
+"""Tests for scan_common.py -- the shared utilities module."""
+
+import unittest
+from pathlib import Path
+
+from helpers import TempProject, import_script
+
+mod = import_script("scan_common")
+
+
+class TestFindProjectRoot(unittest.TestCase):
+    """Project-root detection walks upward looking for markers."""
+
+    def test_finds_root_from_nested_file(self):
+        with TempProject({"pkg/sub/deep.py": "x = 1"}) as root:
+            found = mod.find_project_root(root / "pkg" / "sub" / "deep.py")
+            self.assertEqual(found, root)
+
+    def test_finds_root_from_directory(self):
+        with TempProject({"pkg/mod.py": "x = 1"}) as root:
+            self.assertEqual(mod.find_project_root(root / "pkg"), root)
+
+    def test_root_itself_is_a_marker_dir(self):
+        with TempProject({"mod.py": "x = 1"}) as root:
+            self.assertEqual(mod.find_project_root(root), root)
+
+    def test_no_marker_returns_start_dir(self):
+        # /tmp has no project marker; the start dir comes back unchanged.
+        found = mod.find_project_root(Path("/tmp"))
+        self.assertTrue(found.is_dir())
+
+
+class TestDiscoverPythonFiles(unittest.TestCase):
+    """File discovery skips non-source dirs and is deterministic."""
+
+    def test_finds_nested_python_files(self):
+        with TempProject({"a.py": "", "pkg/b.py": "", "pkg/sub/c.py": ""}) as root:
+            names = {p.name for p in mod.discover_python_files(root)}
+            self.assertEqual(names, {"a.py", "b.py", "c.py"})
+
+    def test_excludes_noise_directories(self):
+        with TempProject(
+            {
+                "real.py": "",
+                ".venv/lib/fake.py": "",
+                "build/gen.py": "",
+                "__pycache__/cached.py": "",
+                "node_modules/dep.py": "",
+            }
+        ) as root:
+            names = {p.name for p in mod.discover_python_files(root)}
+            self.assertEqual(names, {"real.py"})
+
+    def test_excludes_egg_info(self):
+        with TempProject({"real.py": "", "thing.egg-info/pkg.py": ""}) as root:
+            names = {p.name for p in mod.discover_python_files(root)}
+            self.assertEqual(names, {"real.py"})
+
+    def test_single_file_target_yields_itself(self):
+        with TempProject({"only.py": "x = 1"}) as root:
+            found = list(mod.discover_python_files(root / "only.py"))
+            self.assertEqual([p.name for p in found], ["only.py"])
+
+    def test_non_python_file_target_yields_nothing(self):
+        with TempProject({"data.txt": "hi"}) as root:
+            self.assertEqual(list(mod.discover_python_files(root / "data.txt")), [])
+
+    def test_results_are_sorted(self):
+        with TempProject({"c.py": "", "a.py": "", "b.py": ""}) as root:
+            found = list(mod.discover_python_files(root))
+            self.assertEqual(found, sorted(found))
+
+    def test_returns_a_generator_not_a_list(self):
+        # Callers rely on laziness; a regression to list() would be silent.
+        with TempProject({"a.py": ""}) as root:
+            self.assertFalse(isinstance(mod.discover_python_files(root), list))
+
+
+class TestCollectPythonFiles(unittest.TestCase):
+    """The capped collector reports the pre-cap total."""
+
+    def test_reports_total_before_cap(self):
+        with TempProject({f"m{i}.py": "" for i in range(5)}) as root:
+            files, total = mod.collect_python_files(root, max_files=2)
+            self.assertEqual(len(files), 2)
+            self.assertEqual(total, 5)
+
+    def test_no_cap_returns_everything(self):
+        with TempProject({f"m{i}.py": "" for i in range(3)}) as root:
+            files, total = mod.collect_python_files(root, max_files=0)
+            self.assertEqual(len(files), 3)
+            self.assertEqual(total, 3)
+
+    def test_cap_larger_than_corpus_is_a_noop(self):
+        with TempProject({"a.py": "", "b.py": ""}) as root:
+            files, total = mod.collect_python_files(root, max_files=99)
+            self.assertEqual((len(files), total), (2, 2))
+
+
+class TestParseSource(unittest.TestCase):
+    """Parsing never raises on bad input -- scans run over foreign trees."""
+
+    def test_parses_valid_source(self):
+        with TempProject({"ok.py": "def f():\n    return 1\n"}) as root:
+            self.assertIsNotNone(mod.parse_source(root / "ok.py"))
+
+    def test_syntax_error_returns_none(self):
+        with TempProject({"bad.py": "def broken( :\n"}) as root:
+            self.assertIsNone(mod.parse_source(root / "bad.py"))
+
+    def test_missing_file_returns_none(self):
+        self.assertIsNone(mod.parse_source(Path("/nonexistent/nope.py")))
+
+    def test_null_bytes_return_none(self):
+        with TempProject({"nul.py": "x = 1\x00\n"}) as root:
+            self.assertIsNone(mod.parse_source(root / "nul.py"))
+
+
+class TestParseCommonArgs(unittest.TestCase):
+    """CLI parsing matches the contract every script shares."""
+
+    def test_defaults_to_cwd_and_no_cap(self):
+        self.assertEqual(mod.parse_common_args([]), (".", 0))
+
+    def test_positional_target(self):
+        self.assertEqual(mod.parse_common_args(["src/"]), ("src/", 0))
+
+    def test_max_files(self):
+        self.assertEqual(
+            mod.parse_common_args(["src/", "--max-files", "10"]), ("src/", 10)
+        )
+
+    def test_unknown_flags_ignored(self):
+        self.assertEqual(
+            mod.parse_common_args(["--verbose", "src/", "--deep"]), ("src/", 0)
+        )
+
+    def test_bad_max_files_exits_cleanly(self):
+        # Must be SystemExit(2), not an unhandled ValueError traceback.
+        with self.assertRaises(SystemExit) as ctx:
+            mod.parse_common_args(["--max-files", "abc"])
+        self.assertEqual(ctx.exception.code, 2)
+
+
+class TestResolveTarget(unittest.TestCase):
+    """Target resolution distinguishes directory and file targets."""
+
+    def test_directory_target_scans_itself(self):
+        with TempProject({"pkg/m.py": ""}) as root:
+            _, project_root, scan_root = mod.resolve_target(str(root / "pkg"))
+            self.assertEqual(project_root, root)
+            self.assertEqual(scan_root, root / "pkg")
+
+    def test_file_target_scans_project_root(self):
+        with TempProject({"pkg/m.py": ""}) as root:
+            _, project_root, scan_root = mod.resolve_target(str(root / "pkg" / "m.py"))
+            self.assertEqual(project_root, root)
+            self.assertEqual(scan_root, root)
+
+
+class TestBuildEnvelope(unittest.TestCase):
+    """The shared JSON envelope reports capping accurately."""
+
+    def test_not_capped(self):
+        env = mod.build_envelope(Path("/p"), Path("/p/s"), 10, 10)
+        self.assertFalse(env["files_capped"])
+        self.assertEqual(env["files_total"], 10)
+        self.assertEqual(env["project_root"], "/p")
+
+    def test_capped(self):
+        env = mod.build_envelope(Path("/p"), Path("/p"), 10, 4)
+        self.assertTrue(env["files_capped"])
+        self.assertEqual(env["files_analyzed"], 4)
+
+    def test_has_all_shared_keys(self):
+        env = mod.build_envelope(Path("/p"), Path("/p"), 1, 1)
+        self.assertEqual(
+            set(env),
+            {
+                "project_root",
+                "scan_root",
+                "files_total",
+                "files_analyzed",
+                "files_capped",
+            },
+        )
+
+
+class TestDeduplicateFindings(unittest.TestCase):
+    """Dedup keys on (file, line, type) and preserves first-seen order."""
+
+    def test_removes_exact_duplicates(self):
+        findings = [
+            {"file": "a.py", "line": 1, "type": "x"},
+            {"file": "a.py", "line": 1, "type": "x"},
+        ]
+        self.assertEqual(len(mod.deduplicate_findings(findings)), 1)
+
+    def test_keeps_distinct_lines(self):
+        findings = [
+            {"file": "a.py", "line": 1, "type": "x"},
+            {"file": "a.py", "line": 2, "type": "x"},
+        ]
+        self.assertEqual(len(mod.deduplicate_findings(findings)), 2)
+
+    def test_accepts_kind_as_type_alias(self):
+        findings = [
+            {"file": "a.py", "line": 1, "kind": "x"},
+            {"file": "a.py", "line": 1, "kind": "y"},
+        ]
+        self.assertEqual(len(mod.deduplicate_findings(findings)), 2)
+
+    def test_preserves_first_occurrence(self):
+        findings = [
+            {"file": "a.py", "line": 1, "type": "x", "note": "first"},
+            {"file": "a.py", "line": 1, "type": "x", "note": "second"},
+        ]
+        self.assertEqual(mod.deduplicate_findings(findings)[0]["note"], "first")
+
+
+class TestLoadData(unittest.TestCase):
+    """Data loading degrades gracefully on an older checkout."""
+
+    def test_missing_file_returns_empty_dict(self):
+        self.assertEqual(mod.load_data("definitely_not_here.json"), {})
+
+
+class TestRelativeToRoot(unittest.TestCase):
+    """Path relativization falls back to absolute for foreign paths."""
+
+    def test_relative(self):
+        self.assertEqual(
+            mod.relative_to_root(Path("/p/pkg/m.py"), Path("/p")), "pkg/m.py"
+        )
+
+    def test_outside_root_falls_back_to_absolute(self):
+        self.assertEqual(
+            mod.relative_to_root(Path("/other/m.py"), Path("/p")), "/other/m.py"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scan_python_pitfalls.py
+++ b/tests/test_scan_python_pitfalls.py
@@ -1,0 +1,421 @@
+"""Tests for scan_python_pitfalls.py.
+
+Each shape gets a true positive, its guarded twin (which must stay silent), and
+an edge case. The guarded-twin assertions matter most: a scanner that fires on
+the documented fix is worse than no scanner.
+"""
+
+import unittest
+
+from helpers import TempProject, import_script
+
+mod = import_script("scan_python_pitfalls")
+
+
+def scan(source: str, **kw) -> list[dict]:
+    """Scan a single module and return its findings."""
+    with TempProject({"mod.py": source}) as root:
+        return mod.analyze(str(root / "mod.py"), **kw)["findings"]
+
+
+def shapes(source: str) -> list[str]:
+    return [f["shape"] for f in scan(source)]
+
+
+class TestMutableDefault(unittest.TestCase):
+    def test_list_default_mutated(self):
+        f = scan("def f(x, items=[]):\n    items.append(x)\n")
+        self.assertEqual(f[0]["shape"], "mutable-default-argument")
+        self.assertEqual(f[0]["confidence"], "high")
+
+    def test_dict_and_set_defaults(self):
+        self.assertIn(
+            "mutable-default-argument", shapes("def f(a={}):\n    a['k']=1\n")
+        )
+        self.assertIn(
+            "mutable-default-argument", shapes("def f(a=set()):\n    a.add(1)\n")
+        )
+
+    def test_evaluated_once_call(self):
+        src = "import datetime\ndef f(now=datetime.datetime.now()):\n    return now\n"
+        self.assertIn("mutable-default-argument", shapes(src))
+
+    def test_readonly_default_downgraded(self):
+        f = scan("def f(opts={}):\n    print(opts)\n")
+        self.assertEqual(f[0]["confidence"], "medium")
+
+    def test_returned_default_is_high(self):
+        f = scan("def f(items=[]):\n    return items\n")
+        self.assertEqual(f[0]["confidence"], "high")
+
+    def test_keyword_only_default(self):
+        self.assertIn(
+            "mutable-default-argument", shapes("def f(*, x=[]):\n    x.append(1)\n")
+        )
+
+    def test_none_sentinel_is_silent(self):
+        src = "def f(x, items=None):\n    items = [] if items is None else items\n    items.append(x)\n"
+        self.assertNotIn("mutable-default-argument", shapes(src))
+
+    def test_immutable_defaults_silent(self):
+        src = "def f(a=1, b='s', c=(), d=None, e=frozenset()):\n    return a\n"
+        self.assertNotIn("mutable-default-argument", shapes(src))
+
+
+class TestLateBindingClosure(unittest.TestCase):
+    def test_lambda_in_loop(self):
+        src = "def f():\n    out = []\n    for i in range(3):\n        out.append(lambda: i)\n    return out\n"
+        self.assertIn("late-binding-closure-in-loop", shapes(src))
+
+    def test_nested_def_in_loop(self):
+        src = "def f(names):\n    for n in names:\n        def go():\n            return n\n        register(go)\n"
+        self.assertIn("late-binding-closure-in-loop", shapes(src))
+
+    def test_default_arg_binding_is_silent(self):
+        src = "def f():\n    return [lambda i=i: i for i in range(3)]\n"
+        self.assertNotIn("late-binding-closure-in-loop", shapes(src))
+
+    def test_closure_not_using_loop_var_is_silent(self):
+        src = "def f(k):\n    out = []\n    for i in range(3):\n        out.append(lambda: k)\n    return out\n"
+        self.assertNotIn("late-binding-closure-in-loop", shapes(src))
+
+
+class TestExceptOrdering(unittest.TestCase):
+    def test_broad_before_narrow(self):
+        src = "def f():\n    try:\n        pass\n    except Exception:\n        pass\n    except ValueError:\n        pass\n"
+        f = scan(src)
+        self.assertEqual(f[0]["shape"], "except-clause-ordering-unreachable")
+        self.assertEqual(f[0]["confidence"], "high")
+
+    def test_oserror_before_filenotfound(self):
+        src = "def f():\n    try:\n        pass\n    except OSError:\n        pass\n    except FileNotFoundError:\n        pass\n"
+        self.assertIn("except-clause-ordering-unreachable", shapes(src))
+
+    def test_correct_order_is_silent(self):
+        src = "def f():\n    try:\n        pass\n    except ValueError:\n        pass\n    except Exception:\n        pass\n"
+        self.assertNotIn("except-clause-ordering-unreachable", shapes(src))
+
+    def test_unrelated_types_silent(self):
+        src = "def f():\n    try:\n        pass\n    except ValueError:\n        pass\n    except KeyError:\n        pass\n"
+        self.assertNotIn("except-clause-ordering-unreachable", shapes(src))
+
+    def test_user_defined_exceptions_not_guessed(self):
+        # Hierarchy is unknowable statically -- must not fabricate a finding.
+        src = "def f():\n    try:\n        pass\n    except MyBase:\n        pass\n    except MySub:\n        pass\n"
+        self.assertNotIn("except-clause-ordering-unreachable", shapes(src))
+
+
+class TestReturnInFinally(unittest.TestCase):
+    def test_return_in_finally(self):
+        src = "def f():\n    try:\n        raise ValueError\n    finally:\n        return 1\n"
+        self.assertIn("return-or-break-in-finally", shapes(src))
+
+    def test_break_in_finally(self):
+        src = "def f():\n    for _ in range(3):\n        try:\n            pass\n        finally:\n            break\n"
+        self.assertIn("return-or-break-in-finally", shapes(src))
+
+    def test_plain_finally_is_silent(self):
+        src = "def f():\n    try:\n        return compute()\n    finally:\n        release()\n"
+        self.assertNotIn("return-or-break-in-finally", shapes(src))
+
+    def test_return_in_nested_def_is_silent(self):
+        # The return belongs to the inner function, not to the finally.
+        src = "def f():\n    try:\n        pass\n    finally:\n        def helper():\n            return 1\n        helper()\n"
+        self.assertNotIn("return-or-break-in-finally", shapes(src))
+
+
+class TestEqWithoutHash(unittest.TestCase):
+    def test_eq_only(self):
+        self.assertIn(
+            "eq-without-hash",
+            shapes("class C:\n    def __eq__(self, o):\n        return True\n"),
+        )
+
+    def test_eq_and_hash_silent(self):
+        src = "class C:\n    def __eq__(self, o):\n        return True\n    def __hash__(self):\n        return 1\n"
+        self.assertNotIn("eq-without-hash", shapes(src))
+
+    def test_frozen_dataclass_silent(self):
+        src = "from dataclasses import dataclass\n@dataclass(frozen=True)\nclass C:\n    x: int\n    def __eq__(self, o):\n        return True\n"
+        self.assertNotIn("eq-without-hash", shapes(src))
+
+    def test_explicit_hash_none_silent(self):
+        src = "class C:\n    __hash__ = None\n    def __eq__(self, o):\n        return True\n"
+        self.assertNotIn("eq-without-hash", shapes(src))
+
+
+class TestMutationDuringIteration(unittest.TestCase):
+    def test_del_during_dict_iteration(self):
+        self.assertIn(
+            "mutation-during-iteration",
+            shapes("def f(d):\n    for k in d:\n        del d[k]\n"),
+        )
+
+    def test_remove_during_list_iteration(self):
+        self.assertIn(
+            "mutation-during-iteration",
+            shapes("def f(lst):\n    for x in lst:\n        lst.remove(x)\n"),
+        )
+
+    def test_iterating_items_view(self):
+        self.assertIn(
+            "mutation-during-iteration",
+            shapes("def f(d):\n    for k, v in d.items():\n        d.pop(k)\n"),
+        )
+
+    def test_snapshot_is_silent(self):
+        self.assertNotIn(
+            "mutation-during-iteration",
+            shapes("def f(d):\n    for k in list(d):\n        del d[k]\n"),
+        )
+
+    def test_slice_copy_is_silent(self):
+        self.assertNotIn(
+            "mutation-during-iteration",
+            shapes("def f(lst):\n    for x in lst[:]:\n        lst.remove(x)\n"),
+        )
+
+    def test_mutating_a_different_container_silent(self):
+        self.assertNotIn(
+            "mutation-during-iteration",
+            shapes("def f(a, b):\n    for x in a:\n        b.append(x)\n"),
+        )
+
+
+class TestFireAndForgetTask(unittest.TestCase):
+    def test_bare_create_task(self):
+        src = "import asyncio\nasync def f():\n    asyncio.create_task(go())\n"
+        self.assertIn("asyncio-fire-and-forget-task", shapes(src))
+
+    def test_retained_task_is_silent(self):
+        src = "import asyncio\nasync def f(tasks):\n    t = asyncio.create_task(go())\n    tasks.add(t)\n"
+        self.assertNotIn("asyncio-fire-and-forget-task", shapes(src))
+
+    def test_awaited_is_silent(self):
+        src = "import asyncio\nasync def f():\n    await asyncio.create_task(go())\n"
+        self.assertNotIn("asyncio-fire-and-forget-task", shapes(src))
+
+
+class TestBlockingInAsync(unittest.TestCase):
+    def test_time_sleep(self):
+        src = "import time\nasync def f():\n    time.sleep(1)\n"
+        self.assertIn("blocking-call-in-async-function", shapes(src))
+
+    def test_requests_get(self):
+        src = "import requests\nasync def f():\n    requests.get('u')\n"
+        self.assertIn("blocking-call-in-async-function", shapes(src))
+
+    def test_asyncio_sleep_is_silent(self):
+        src = "import asyncio\nasync def f():\n    await asyncio.sleep(1)\n"
+        self.assertNotIn("blocking-call-in-async-function", shapes(src))
+
+    def test_blocking_in_sync_function_is_silent(self):
+        src = "import time\ndef f():\n    time.sleep(1)\n"
+        self.assertNotIn("blocking-call-in-async-function", shapes(src))
+
+
+class TestUnawaitedCoroutine(unittest.TestCase):
+    def test_bare_call_to_local_coroutine(self):
+        src = "async def work():\n    return 1\nasync def caller():\n    work()\n"
+        self.assertIn("unawaited-coroutine", shapes(src))
+
+    def test_awaited_is_silent(self):
+        src = "async def work():\n    return 1\nasync def caller():\n    await work()\n"
+        self.assertNotIn("unawaited-coroutine", shapes(src))
+
+    def test_gathered_is_silent(self):
+        src = "import asyncio\nasync def work():\n    return 1\nasync def caller():\n    await asyncio.gather(work(), work())\n"
+        self.assertNotIn("unawaited-coroutine", shapes(src))
+
+    def test_sync_function_call_is_silent(self):
+        src = "def work():\n    return 1\nasync def caller():\n    work()\n"
+        self.assertNotIn("unawaited-coroutine", shapes(src))
+
+
+class TestLruCacheOnMethod(unittest.TestCase):
+    def test_lru_cache_with_self(self):
+        src = "import functools\nclass C:\n    @functools.lru_cache\n    def m(self, k):\n        return k\n"
+        self.assertIn("lru-cache-on-method", shapes(src))
+
+    def test_cached_property_is_silent(self):
+        src = "import functools\nclass C:\n    @functools.cached_property\n    def m(self):\n        return 1\n"
+        self.assertNotIn("lru-cache-on-method", shapes(src))
+
+    def test_module_level_function_is_silent(self):
+        src = "import functools\n@functools.lru_cache\ndef f(k):\n    return k\n"
+        self.assertNotIn("lru-cache-on-method", shapes(src))
+
+    def test_staticmethod_is_silent(self):
+        src = "import functools\nclass C:\n    @staticmethod\n    @functools.lru_cache\n    def m(k):\n        return k\n"
+        self.assertNotIn("lru-cache-on-method", shapes(src))
+
+
+class TestClassLevelMutable(unittest.TestCase):
+    def test_class_list(self):
+        f = scan("class C:\n    items = []\n")
+        self.assertEqual(f[0]["shape"], "class-level-mutable-attribute")
+        self.assertEqual(f[0]["confidence"], "high")
+
+    def test_all_caps_downgraded(self):
+        f = scan("class C:\n    DEFAULTS = {}\n")
+        self.assertEqual(f[0]["confidence"], "medium")
+
+    def test_instance_attribute_is_silent(self):
+        src = "class C:\n    def __init__(self):\n        self.items = []\n"
+        self.assertNotIn("class-level-mutable-attribute", shapes(src))
+
+    def test_dataclass_field_is_silent(self):
+        src = "from dataclasses import dataclass, field\n@dataclass\nclass C:\n    items: list = field(default_factory=list)\n"
+        self.assertNotIn("class-level-mutable-attribute", shapes(src))
+
+    def test_immutable_class_attribute_is_silent(self):
+        self.assertNotIn(
+            "class-level-mutable-attribute", shapes("class C:\n    NAME = 'x'\n")
+        )
+
+
+class TestBareExcept(unittest.TestCase):
+    def test_bare_except(self):
+        f = scan("def f():\n    try:\n        pass\n    except:\n        pass\n")
+        self.assertEqual(f[0]["shape"], "bare-except-swallows-control-flow")
+        self.assertEqual(f[0]["confidence"], "high")
+
+    def test_base_exception(self):
+        src = "def f():\n    try:\n        pass\n    except BaseException:\n        pass\n"
+        self.assertIn("bare-except-swallows-control-flow", shapes(src))
+
+    def test_reraise_is_silent(self):
+        src = "def f():\n    try:\n        pass\n    except BaseException:\n        raise\n"
+        self.assertNotIn("bare-except-swallows-control-flow", shapes(src))
+
+    def test_captured_for_caller_downgraded(self):
+        # The thread/worker-body pattern: capture now, re-raise in the caller.
+        src = "def f(errs):\n    try:\n        pass\n    except BaseException as e:\n        errs.append(e)\n"
+        f = [x for x in scan(src) if x["shape"] == "bare-except-swallows-control-flow"]
+        self.assertEqual(f[0]["confidence"], "medium")
+
+    def test_except_exception_is_silent(self):
+        src = "def f():\n    try:\n        pass\n    except Exception:\n        pass\n"
+        self.assertNotIn("bare-except-swallows-control-flow", shapes(src))
+
+
+class TestExceptionInDel(unittest.TestCase):
+    def test_unguarded_del(self):
+        src = "class C:\n    def __del__(self):\n        self.handle.close()\n"
+        self.assertIn("exception-in-del-or-finalizer", shapes(src))
+
+    def test_guarded_del_is_silent(self):
+        src = "class C:\n    def __del__(self):\n        try:\n            self.handle.close()\n        except Exception:\n            pass\n"
+        self.assertNotIn("exception-in-del-or-finalizer", shapes(src))
+
+    def test_trivial_del_is_silent(self):
+        src = "class C:\n    def __del__(self):\n        self.closed = True\n"
+        self.assertNotIn("exception-in-del-or-finalizer", shapes(src))
+
+
+class TestIsLiteral(unittest.TestCase):
+    def test_is_int_literal(self):
+        self.assertIn(
+            "is-comparison-with-literal", shapes("def f(x):\n    return x is 256\n")
+        )
+
+    def test_is_str_literal(self):
+        self.assertIn(
+            "is-comparison-with-literal", shapes("def f(x):\n    return x is 'name'\n")
+        )
+
+    def test_is_none_is_silent(self):
+        self.assertNotIn(
+            "is-comparison-with-literal", shapes("def f(x):\n    return x is None\n")
+        )
+
+    def test_is_bool_is_silent(self):
+        src = "def f(x):\n    return x is True or x is False\n"
+        self.assertNotIn("is-comparison-with-literal", shapes(src))
+
+    def test_equality_is_silent(self):
+        self.assertNotIn(
+            "is-comparison-with-literal", shapes("def f(x):\n    return x == 256\n")
+        )
+
+
+class TestEnvelopeAndOptions(unittest.TestCase):
+    def test_envelope_keys(self):
+        with TempProject({"m.py": "x = 1\n"}) as root:
+            result = mod.analyze(str(root))
+        for key in (
+            "project_root",
+            "scan_root",
+            "files_total",
+            "files_analyzed",
+            "files_capped",
+        ):
+            self.assertIn(key, result)
+        for key in (
+            "by_shape",
+            "by_severity",
+            "by_confidence",
+            "by_directory",
+            "checks_run",
+        ):
+            self.assertIn(key, result["summary"])
+
+    def test_file_target_scans_only_that_file(self):
+        # Pointing at one file must not silently scan the whole project.
+        with TempProject(
+            {
+                "a.py": "def f(x=[]):\n    x.append(1)\n",
+                "b.py": "def g(y=[]):\n    y.append(1)\n",
+            }
+        ) as root:
+            result = mod.analyze(str(root / "a.py"))
+        self.assertEqual(result["files_analyzed"], 1)
+        self.assertEqual(result["summary"]["total_findings"], 1)
+
+    def test_check_filter(self):
+        src = "def f(x=[]):\n    x.append(1)\ndef g():\n    return 1 is 2\n"
+        with TempProject({"m.py": src}) as root:
+            result = mod.analyze(str(root), checks=["is-comparison-with-literal"])
+        found = {f["shape"] for f in result["findings"]}
+        self.assertEqual(found, {"is-comparison-with-literal"})
+
+    def test_exclude_pattern(self):
+        files = {
+            "src/a.py": "def f(x=[]):\n    x.append(1)\n",
+            "generated/b.py": "def g(y=[]):\n    y.append(1)\n",
+        }
+        with TempProject(files) as root:
+            result = mod.analyze(str(root), exclude=["generated/"])
+        self.assertEqual(result["summary"]["total_findings"], 1)
+        self.assertIn("src", result["summary"]["by_directory"])
+
+    def test_findings_are_sorted(self):
+        with TempProject(
+            {"m.py": "def f(x=[]):\n    x.append(1)\ndef g(y=[]):\n    y.append(1)\n"}
+        ) as root:
+            findings = mod.analyze(str(root))["findings"]
+        keys = [(f["file"], f["line"], f["shape"]) for f in findings]
+        self.assertEqual(keys, sorted(keys))
+
+    def test_syntax_error_file_does_not_abort(self):
+        files = {
+            "bad.py": "def broken( :\n",
+            "good.py": "def f(x=[]):\n    x.append(1)\n",
+        }
+        with TempProject(files) as root:
+            result = mod.analyze(str(root))
+        self.assertEqual(result["summary"]["total_findings"], 1)
+
+    def test_every_check_maps_to_a_catalogued_shape(self):
+        catalog = import_script("build_informed_briefing")
+        ids = {s["id"] for s in catalog._load_shapes()}
+        self.assertEqual(set(mod._CHECKS) - ids, set())
+
+    def test_every_finding_carries_required_fields(self):
+        findings = scan("def f(x=[]):\n    x.append(1)\n")
+        for key in ("shape", "severity", "confidence", "file", "line", "message"):
+            self.assertIn(key, findings[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

code-review-toolkit was the least-developed of the seven review toolkits — but **not in build quality** (300 tests passing, lint clean). The deficit was **calibration**: every sibling improved through the loop *run on real code → confirm/dismiss → encode in `data/` → re-review informed*, and this toolkit had no `data/` layer to run it with.

- **`scan_common.py`** — `find_project_root` was byte-identical in all 9 scripts and `discover_python_files` had **already drifted into 3 divergent variants**. Now one definition each; output verified **byte-identical** before/after on two separate targets.
- **Knowledge layer** — `python_bug_shapes.json` (14 shapes, each with its *guarded twin*, sibling-hunt directive, and differential) and `python_non_bugs.md` (15-class FP taxonomy, each with the real-bug discriminator).
- **Informed review** — `build_informed_briefing.py` + the `informed-explore` command; `explore` gains `--runs N` / `--informed-reruns` so the 2-naive + 1-informed methodology is expressible.
- **`python-pitfall-scanner` + `scan_python_pitfalls.py`** — the toolkit's first bug-finding agent. 14 AST checks mapping **1:1** to the catalogued shapes, so a finding traces back to its template. The builtin exception hierarchy is read from the running interpreter rather than a hardcoded table.
- **`CLAUDE.md`**, including an explicit *Known gaps* section.

## What running it on real code taught us

The calibration loop, working as intended:

1. **Generated content dominates the FP surface** — 99 of 100 findings in one project were in generated stress scripts; another project's were all in golden fixtures. Hence `--exclude` and the `by_directory` breakdown, so a whole directory is triaged at once rather than hit by hit.
2. **The thread/worker capture pattern is legitimate** — `except BaseException as e: errs.append(e)` lets the caller re-raise. Downgraded to `medium` with the discriminator stated.
3. **A single-file target silently scanned the whole project** (`scan_root` fell back to the project root) — the same trap documented in cext-review-toolkit's gotchas.

Net on a real 461-file project with generated content excluded: **1 finding**, medium confidence.

## Bugs fixed along the way

- `--max-files abc` exited with a raw `ValueError` traceback.
- `extract_test_invariants.py` emitted set-iteration order, so output varied with `PYTHONHASHSEED` — which would have silently defeated the cross-run dedup in the `--runs N` feature being added here.
- `correlate_tests.py` omitted `scan_root` from its envelope.
- README counts claimed 14 agents / 4 commands / 7 scripts; actual is **16 / 5 / 12** — drift in the toolkit that ships a `project-docs-auditor`.

## Test plan

- [x] `python -m unittest discover tests` — **432 tests pass** (was 300)
- [x] `ruff check` / `ruff format --check` clean on all new and changed files
- [x] Refactor verified behaviour-preserving: byte-identical JSON output before/after across 7 scripts on 2 targets
- [x] All 14 shapes fire on the bad fixture; **zero** fire on the guarded-twin fixture (the documented fix for each)
- [x] Scanner exercised on 3 real codebases (461, 180, 24 files)

## Deliberately out of scope

`known-issues` and the `code-review-findings` companion repo both need a first validation run to have real content. The `.code-review/findings.json` schema is already wire-compatible with the sibling findings repos, so that hand-off will be a copy rather than a conversion.

Note: `ruff format` across the whole tree would rewrite ~1500 lines of untouched code (the repo has no ruff config and was never uniformly formatted). Only files touched here are formatted, so this diff stays reviewable; normalizing the tree is worth doing as its own commit.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oHTKJMM4ThdosDumvAFek