### PR TITLE
Adopt five bug shapes from the 40-bug CPython stdlib audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Five new bug shapes derived from a 40-bug audit of CPython's pure-Python stdlib** — the catalog
+  previously covered *none* of that audit's pattern families. Added `except-exception-too-broad`
+  (~50% of the audit's confirmed findings: `except Exception:` around a narrow operation with a
+  swallowing handler), `cleanup-only-on-success-path` (~20%: `close()`/`quit()` at the end of a `try`
+  instead of in `finally`), `error-reported-below-warning` (~17%: failures logged only at
+  debug/info, invisible under default configuration), `except-in-loop-without-exit` (a persistent
+  failure inside `while True:` becomes a silent hang), and `raise-without-from-in-except`. Catalog is
+  now 19 shapes.
 - **New agent + script: `python-pitfall-scanner` / `scan_python_pitfalls.py`** — the toolkit's first
   dedicated bug-finding capability. Fourteen AST checks mapping 1:1 to the shapes in
   `python_bug_shapes.json`, each emitting a confidence level (`high`/`medium`/`low`) derived from that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ candidates, and prints JSON to stdout.
 | Script | Purpose |
 |---|---|
 | `scan_common.py` | **Shared utilities — every other script imports from here** |
-| `scan_python_pitfalls.py` | Correctness defects; 14 checks mapping 1:1 to `data/python_bug_shapes.json` |
+| `scan_python_pitfalls.py` | Correctness defects; 19 checks mapping 1:1 to `data/python_bug_shapes.json` |
 | `analyze_imports.py` | Import graph, module boundaries, circular dependencies |
 | `analyze_history.py` | Git history: churn, co-change, fix density |
 | `measure_complexity.py` | Per-function complexity metrics |

--- a/plugins/code-review-toolkit/data/python_bug_shapes.json
+++ b/plugins/code-review-toolkit/data/python_bug_shapes.json
@@ -264,6 +264,101 @@
       ],
       "differential": "`is None` / `is True` / `is False` and sentinel-object comparisons are correct and must not be flagged.",
       "detected_by": "scan_python_pitfalls.py"
+    },
+    {
+      "id": "except-exception-too-broad",
+      "title": "`except Exception:` around a narrow operation swallows unrelated failures",
+      "agent": "python-pitfall-scanner",
+      "severity": "FIX",
+      "pattern": "A `try` whose body is one or two narrow operations -- a single attribute access, one call, one parse -- wrapped in `except Exception:` (or `except BaseException:`) whose handler swallows: `pass`, or assigning a default/`None`, or `return`ing a fallback. The author meant one specific failure (`AttributeError`, `TypeError`, `ValueError`); everything else -- `RuntimeError`, `MemoryError`, a genuine bug in the callee -- is silently absorbed and reported as the expected condition.",
+      "guarded_twin": "The same operation elsewhere guarded by the SPECIFIC exception it can raise: `except AttributeError:` for an attribute chain, `except (TypeError, ValueError):` for a parse. Most codebases already contain the narrow form somewhere -- find it and match it.",
+      "hunt": "For each instance, grep every other site performing the same operation (same method, same parse, same attribute chain). Broad catches propagate by copy-paste, and the narrow twin is usually adjacent.",
+      "expected": "the anticipated failure is handled; anything else propagates so it can be seen and fixed.",
+      "caught_as": "SILENT -- a genuine bug in the guarded call is indistinguishable from the expected condition. Frequently surfaces much later as an empty result, a `None`, or a missing side effect.",
+      "confirmed_examples": [],
+      "validation": "documented",
+      "references": [
+        "Derived from a 40-bug audit of CPython's pure-Python stdlib (gist 3198710e3c0128fda5e0a7b4e0768e5f), where this family accounted for ~50% of all confirmed findings (20 of 40).",
+        "Instances there: typing.py x4, argparse.py, subprocess.py, http/cookiejar.py, xml.sax, xml.dom.domreg",
+        "ruff BLE001 blind-except"
+      ],
+      "differential": "A broad catch at a genuine trust boundary is legitimate: a plugin/entry-point loader, a top-level CLI handler, or a call into user-supplied code -- ESPECIALLY when it logs at warning+ or re-raises, or carries a comment explaining the containment. The discriminator is the size and nature of the try body: one narrow operation = too broad; a whole subsystem call at a boundary = fine.",
+      "detected_by": "scan_python_pitfalls.py"
+    },
+    {
+      "id": "cleanup-only-on-success-path",
+      "title": "Resource released at the end of `try` instead of in `finally` -- leaked on the error path",
+      "agent": "python-pitfall-scanner",
+      "severity": "FIX",
+      "pattern": "A resource is acquired, used, and released (`close()`, `quit()`, `shutdown()`, `release()`, `disconnect()`) as the LAST statement of a `try` body, with `except` clauses but no `finally`. Any exception raised mid-body skips the release, leaking a file descriptor, socket, or connection.",
+      "guarded_twin": "`finally: resource.close()`, or a `with` block. A sibling function in the same module usually already does it correctly.",
+      "hunt": "Audit every acquire/release pair in the module. Also check `__exit__`/`close()` methods that release several resources in sequence -- an exception on the first leaks the rest.",
+      "expected": "the resource is released on every path, success or failure.",
+      "caught_as": "SILENT under normal operation; surfaces only under load or after repeated failures as fd exhaustion, connection-pool starvation, or `ResourceWarning: unclosed ...` at GC time.",
+      "confirmed_examples": [],
+      "validation": "documented",
+      "references": [
+        "Derived from a 40-bug audit of CPython's pure-Python stdlib (gist 3198710e3c0128fda5e0a7b4e0768e5f), where this family accounted for ~20% of confirmed findings (8 of 40).",
+        "Instances there: logging.handlers SMTP `quit()` not in finally; shutil partial cleanup on cross-device move; xml.sax.saxutils and xml.dom.pulldom missing close"
+      ],
+      "differential": "Fine if the resource is returned to the caller (ownership transfers), if a `with` block already governs it, or if the except clause itself performs the release. Confirm no path skips it.",
+      "detected_by": "scan_python_pitfalls.py"
+    },
+    {
+      "id": "error-reported-below-warning",
+      "title": "Failure reported only at debug/info level -- invisible under default logging",
+      "agent": "python-pitfall-scanner",
+      "severity": "CONSIDER",
+      "pattern": "An `except` handler whose ONLY reporting is `logger.debug(...)` / `logger.info(...)` / `util.debug(...)` / `print` to a non-default stream, with no re-raise and no state change signalling failure. Default logging configuration discards DEBUG and INFO, so the failure produces literally no output in production.",
+      "guarded_twin": "`logger.warning(...)`/`logger.exception(...)` for a genuine failure; debug level is for tracing, not for errors. The same module usually logs comparable failures at warning or above.",
+      "hunt": "Grep every `debug(`/`info(` call inside an except handler across the project; also check whether the module's logger is even configured by default.",
+      "expected": "an operator running with default configuration can tell the operation failed.",
+      "caught_as": "SILENT in production by construction -- the report exists in source, so a reader believes it is handled, but nothing reaches the logs.",
+      "confirmed_examples": [],
+      "validation": "documented",
+      "references": [
+        "Derived from a 40-bug audit of CPython's pure-Python stdlib (gist 3198710e3c0128fda5e0a7b4e0768e5f), where this family accounted for ~17% of confirmed findings (7 of 40).",
+        "Instances there: multiprocessing proxy-refcount failure at debug level; after-fork callback failures at info level; logging.handlers ignoring HTTP response status"
+      ],
+      "differential": "Debug level is correct for genuinely-expected, high-frequency, non-actionable conditions (a cache miss, an optional import). The discriminator: would an operator want to know? If the handler is recovering from something that should not normally happen, it belongs at warning+.",
+      "detected_by": "scan_python_pitfalls.py"
+    },
+    {
+      "id": "except-in-loop-without-exit",
+      "title": "Swallowed exception inside an unbounded loop -- a persistent failure becomes a hang",
+      "agent": "python-pitfall-scanner",
+      "severity": "FIX",
+      "pattern": "A `while True:` (or a retry loop) containing a `try`/`except` whose handler neither breaks, returns, raises, nor increments a bounded attempt counter -- typically `except OSError: pass` or `except Exception: continue`. If the failure is transient the loop recovers; if it is persistent the process spins forever with no diagnostic.",
+      "guarded_twin": "A bounded retry: `for attempt in range(N)` with a final re-raise, or a `break`/`raise` after a threshold. Backoff loops elsewhere in the same module usually show the correct shape.",
+      "hunt": "Every unbounded loop containing a try/except. Also check loops that poll a resource which can be permanently unavailable (a deleted directory, a closed socket, a dead peer).",
+      "expected": "a persistent failure terminates the loop with a diagnostic instead of spinning.",
+      "caught_as": "A HANG with no output -- the worst diagnostic profile of any shape here, because there is no exception, no log line, and no exit.",
+      "confirmed_examples": [],
+      "validation": "documented",
+      "references": [
+        "Derived from a 40-bug audit of CPython's pure-Python stdlib (gist 3198710e3c0128fda5e0a7b4e0768e5f), where this family accounted for an instance in importlib._bootstrap_external: `except OSError: pass` in a `while True:` directory scan, which hangs the process indefinitely."
+      ],
+      "differential": "Correct for an event loop or server accept-loop that MUST survive individual failures -- but even those should log. The discriminator: can the guarded operation fail permanently? If yes, the loop needs an exit.",
+      "detected_by": "scan_python_pitfalls.py"
+    },
+    {
+      "id": "raise-without-from-in-except",
+      "title": "Re-raising a new exception inside `except` without `from` loses the cause",
+      "agent": "python-pitfall-scanner",
+      "severity": "CONSIDER",
+      "pattern": "`raise NewError(...)` inside an `except` handler with no `from err` and no `from None`. Python still records the original as implicit context, but the explicit cause is lost and tooling/readers cannot distinguish 'this replaced that deliberately' from 'the author forgot'. The severe variant passes the wrong object entirely -- e.g. `raise TypeError(msg, err.__traceback__)`, which stuffs a traceback object into `args` instead of chaining.",
+      "guarded_twin": "`raise NewError(...) from err` to chain, or `from None` to deliberately suppress. Both are explicit and both read correctly.",
+      "hunt": "Every `raise` inside an `except` in the module; the convention is applied per-codebase, so a module that chains in one place and not another has a real inconsistency.",
+      "expected": "the traceback shows the original cause, explicitly marked as cause or deliberately suppressed.",
+      "caught_as": "Visible in the traceback as 'During handling of the above exception, another exception occurred' rather than 'The above exception was the direct cause' -- confusing rather than silent, but it degrades every downstream diagnosis.",
+      "confirmed_examples": [],
+      "validation": "documented",
+      "references": [
+        "Derived from a 40-bug audit of CPython's pure-Python stdlib (gist 3198710e3c0128fda5e0a7b4e0768e5f), where this family accounted for the pickle.py instance, where a traceback object is passed as a constructor argument instead of being chained.",
+        "ruff B904 raise-without-from-inside-except"
+      ],
+      "differential": "Not a defect when the new exception is genuinely unrelated to the caught one and `from None` would be noise, or in code targeting Python 2 compatibility. Judge by whether the original would help someone debugging.",
+      "detected_by": "scan_python_pitfalls.py"
     }
   ]
 }

--- a/plugins/code-review-toolkit/data/python_non_bugs.md
+++ b/plugins/code-review-toolkit/data/python_non_bugs.md
@@ -195,3 +195,14 @@ run that produced it, so the evidence is traceable.
 - **Real bug:** the *remaining* control-flow exceptions. In the `rpc.py` shape `SystemExit` is
   re-raised but `KeyboardInterrupt` is still swallowed, so the finding is real but narrower than it
   first appears. Name precisely which exceptions remain swallowed.
+
+### 21. Poll loop draining a queue or socket *(idlelib `rpc.py:424`, `run.py:166`)*
+- **Symptom:** `while True: ... except queue.Empty: pass` flagged as a swallowed exception in an
+  unbounded loop (the "persistent failure hangs the process" shape).
+- **Why non-bug:** `queue.Empty`, `TimeoutError`, `socket.timeout`, `BlockingIOError` and
+  `InterruptedError` mean *"nothing ready right now"*, not *"this failed"*. Catching one and
+  continuing **is** the design of an event loop; the body goes on to do other work before retrying.
+- **Real bug:** the caught exception denotes an actual failure that can be permanent — the gist's
+  genuine instance was `except OSError: pass` around a directory scan in
+  `importlib._bootstrap_external`, which spins forever if the directory is gone. The discriminator is
+  the exception's *meaning*, not the loop shape.

--- a/plugins/code-review-toolkit/scripts/scan_python_pitfalls.py
+++ b/plugins/code-review-toolkit/scripts/scan_python_pitfalls.py
@@ -947,6 +947,289 @@ def _check_is_literal(tree: ast.AST) -> list[dict]:
     return out
 
 
+# --------------------------------------------------------------------------
+# Shapes derived from a 40-bug audit of CPython's pure-Python stdlib.
+# Overly-broad `except Exception:` alone accounted for ~50% of those findings.
+# --------------------------------------------------------------------------
+
+# Releasing a resource. Not exhaustive by design -- these are the verbs whose
+# omission on an error path actually leaks something.
+_RELEASE_METHODS = frozenset(
+    {"close", "quit", "shutdown", "release", "disconnect", "terminate", "unlink"}
+)
+
+# Logging calls too quiet to surface a failure under default configuration.
+_QUIET_LOG_METHODS = frozenset({"debug", "info"})
+_LOUD_LOG_METHODS = frozenset(
+    {"warning", "warn", "error", "exception", "critical", "fatal"}
+)
+
+
+def _handler_swallows(handler: ast.ExceptHandler) -> bool:
+    """True if the handler neither re-raises nor propagates a failure signal.
+
+    `pass`, a bare default assignment, or returning a fallback all mean the
+    caller cannot tell the operation failed.
+    """
+    if any(isinstance(n, ast.Raise) for n in ast.walk(handler)):
+        return False
+    for stmt in handler.body:
+        if isinstance(stmt, ast.Pass):
+            continue
+        if isinstance(stmt, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
+            continue
+        if isinstance(stmt, ast.Return):
+            continue
+        if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+            # A logging/reporting call is still swallowing unless it is loud.
+            name = _call_name(stmt.value)
+            tail = name.split(".")[-1] if name else ""
+            if tail in _QUIET_LOG_METHODS or tail in _LOUD_LOG_METHODS:
+                continue
+            return False
+        return False
+    return True
+
+
+def _check_except_exception_too_broad(tree: ast.AST) -> list[dict]:
+    out: list[dict] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Try):
+            continue
+        # A narrow try body is the signal: the author guarded one operation.
+        narrow = len(node.body) <= 2
+        for handler in node.handlers:
+            if not isinstance(handler.type, ast.Name):
+                continue
+            if handler.type.id not in {"Exception", "BaseException"}:
+                continue
+            if not _handler_swallows(handler):
+                continue
+            # A loud log makes the failure visible -- not silent, so not FIX.
+            loud = any(
+                isinstance(n, ast.Call)
+                and (_call_name(n).split(".")[-1] if _call_name(n) else "")
+                in _LOUD_LOG_METHODS
+                for n in ast.walk(handler)
+            )
+            if narrow and not loud:
+                conf = "high"
+                why = (
+                    f"the try body is {len(node.body)} statement(s) -- one narrow "
+                    f"operation guarded by a catch-all"
+                )
+            elif narrow:
+                conf, why = (
+                    "medium",
+                    "narrow try body, but the handler logs loudly -- confirm the "
+                    "broad catch is deliberate containment",
+                )
+            else:
+                conf, why = (
+                    "low",
+                    "large try body: may be a genuine boundary (plugin loader, CLI "
+                    "top level, call into user code) -- check for a rationale",
+                )
+            out.append(
+                _finding(
+                    "except-exception-too-broad",
+                    "FIX",
+                    conf,
+                    handler,
+                    f"`except {handler.type.id}:` swallows every failure of the "
+                    f"guarded operation, not just the expected one",
+                    why,
+                )
+            )
+    return out
+
+
+def _check_cleanup_only_on_success(tree: ast.AST) -> list[dict]:
+    out: list[dict] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Try) or not node.handlers or node.finalbody:
+            continue
+        if not node.body:
+            continue
+        last = node.body[-1]
+        if not (isinstance(last, ast.Expr) and isinstance(last.value, ast.Call)):
+            continue
+        call = last.value
+        if not isinstance(call.func, ast.Attribute):
+            continue
+        verb = call.func.attr
+        if verb not in _RELEASE_METHODS:
+            continue
+        target = _dotted_name(call.func.value) or "<resource>"
+        # If a handler also releases it, the error path is covered.
+        released_in_handler = any(
+            isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Attribute)
+            and n.func.attr == verb
+            for h in node.handlers
+            for n in ast.walk(h)
+        )
+        if released_in_handler:
+            continue
+        out.append(
+            _finding(
+                "cleanup-only-on-success-path",
+                "FIX",
+                "high" if len(node.body) > 1 else "medium",
+                last,
+                f"`{target}.{verb}()` runs only when the try body succeeds; an "
+                f"exception above it leaks the resource",
+                "move it to a `finally:` block, or use a `with` statement",
+            )
+        )
+    return out
+
+
+def _check_error_reported_below_warning(tree: ast.AST) -> list[dict]:
+    out: list[dict] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ExceptHandler):
+            continue
+        if any(isinstance(n, ast.Raise) for n in ast.walk(node)):
+            continue
+        quiet: list[str] = []
+        loud = False
+        for inner in ast.walk(node):
+            if not isinstance(inner, ast.Call):
+                continue
+            name = _call_name(inner)
+            tail = name.split(".")[-1] if name else ""
+            if tail in _LOUD_LOG_METHODS:
+                loud = True
+            elif tail in _QUIET_LOG_METHODS and name:
+                quiet.append(name)
+        if loud or not quiet:
+            continue
+        out.append(
+            _finding(
+                "error-reported-below-warning",
+                "CONSIDER",
+                "medium",
+                node,
+                f"the only report of this failure is {quiet[0]}(...), which default "
+                f"logging configuration discards",
+                "an operator running with defaults sees nothing; use warning/exception "
+                "if the condition is actionable",
+            )
+        )
+    return out
+
+
+# "Nothing to do right now" signals. Catching one of these in a poll loop and
+# continuing IS the design -- an event loop that drains a queue with a timeout
+# is not a hang. Observed on idlelib's rpc.py/run.py event loops, where every
+# raw hit was this pattern; the gist's genuine instance was `except OSError:`
+# on a directory scan, where the error means real failure.
+_POLL_SIGNAL_EXCEPTIONS = frozenset(
+    {
+        "Empty",
+        "Full",
+        "queue.Empty",
+        "queue.Full",
+        "timeout",
+        "socket.timeout",
+        "TimeoutError",
+        "BlockingIOError",
+        "InterruptedError",
+        "asyncio.TimeoutError",
+        "KeyboardInterrupt",
+    }
+)
+
+
+def _is_poll_signal(handler: ast.ExceptHandler) -> bool:
+    """True if the handler catches only 'nothing ready yet' conditions."""
+    if handler.type is None:
+        return False
+    parts = handler.type.elts if isinstance(handler.type, ast.Tuple) else [handler.type]
+    names = {_dotted_name(p) for p in parts}
+    names |= {n.split(".")[-1] for n in names if n}
+    caught = {n for n in names if n}
+    # An unresolvable name (not a plain Name/Attribute) means we cannot tell.
+    if len(caught) < len(parts):
+        return False
+    return bool(caught) and caught <= _POLL_SIGNAL_EXCEPTIONS
+
+
+def _check_except_in_loop_without_exit(tree: ast.AST) -> list[dict]:
+    out: list[dict] = []
+    for loop in ast.walk(tree):
+        # Unbounded loop only: `while True:` / `while 1:`.
+        if not isinstance(loop, ast.While):
+            continue
+        test = loop.test
+        unbounded = (isinstance(test, ast.Constant) and bool(test.value)) or (
+            isinstance(test, ast.Name) and test.id == "True"
+        )
+        if not unbounded:
+            continue
+        for node in ast.walk(loop):
+            if not isinstance(node, ast.Try):
+                continue
+            for handler in node.handlers:
+                # Any exit from the loop discharges the obligation.
+                exits = any(
+                    isinstance(n, (ast.Break, ast.Return, ast.Raise))
+                    for n in ast.walk(handler)
+                )
+                if exits:
+                    continue
+                if _is_poll_signal(handler):
+                    continue  # poll loop draining a queue/socket, not a hang
+                if not _handler_swallows(handler):
+                    continue
+                label = (
+                    ast.unparse(handler.type) if handler.type is not None else "bare"
+                )
+                out.append(
+                    _finding(
+                        "except-in-loop-without-exit",
+                        "FIX",
+                        "high",
+                        handler,
+                        f"`except {label}` inside `while True:` neither breaks, returns "
+                        f"nor raises; a persistent failure spins forever",
+                        "a transient failure recovers, but a permanent one hangs the "
+                        "process with no diagnostic -- bound the retries",
+                    )
+                )
+    return out
+
+
+def _check_raise_without_from(tree: ast.AST) -> list[dict]:
+    out: list[dict] = []
+    for handler in ast.walk(tree):
+        if not isinstance(handler, ast.ExceptHandler):
+            continue
+        for node in ast.walk(handler):
+            if not isinstance(node, ast.Raise):
+                continue
+            if node.exc is None:  # bare `raise` re-raises; correct
+                continue
+            if node.cause is not None:  # explicit `from err` / `from None`
+                continue
+            # Re-raising the caught name itself needs no cause.
+            if isinstance(node.exc, ast.Name) and node.exc.id == handler.name:
+                continue
+            out.append(
+                _finding(
+                    "raise-without-from-in-except",
+                    "CONSIDER",
+                    "medium",
+                    node,
+                    "raising a new exception inside `except` without `from` loses the "
+                    "explicit cause",
+                    "use `from err` to chain or `from None` to suppress deliberately",
+                )
+            )
+    return out
+
+
 _CHECKS = {
     "mutable-default-argument": _check_mutable_default,
     "late-binding-closure-in-loop": _check_late_binding_closure,
@@ -962,6 +1245,11 @@ _CHECKS = {
     "bare-except-swallows-control-flow": _check_bare_except,
     "exception-in-del-or-finalizer": _check_exception_in_del,
     "is-comparison-with-literal": _check_is_literal,
+    "except-exception-too-broad": _check_except_exception_too_broad,
+    "cleanup-only-on-success-path": _check_cleanup_only_on_success,
+    "error-reported-below-warning": _check_error_reported_below_warning,
+    "except-in-loop-without-exit": _check_except_in_loop_without_exit,
+    "raise-without-from-in-except": _check_raise_without_from,
 }
 
 

--- a/tests/test_scan_python_pitfalls.py
+++ b/tests/test_scan_python_pitfalls.py
@@ -83,8 +83,10 @@ class TestLateBindingClosure(unittest.TestCase):
 class TestExceptOrdering(unittest.TestCase):
     def test_broad_before_narrow(self):
         src = "def f():\n    try:\n        pass\n    except Exception:\n        pass\n    except ValueError:\n        pass\n"
-        f = scan(src)
-        self.assertEqual(f[0]["shape"], "except-clause-ordering-unreachable")
+        # The same fixture also legitimately triggers except-exception-too-broad,
+        # so select by shape rather than by position.
+        f = [x for x in scan(src) if x["shape"] == "except-clause-ordering-unreachable"]
+        self.assertEqual(len(f), 1)
         self.assertEqual(f[0]["confidence"], "high")
 
     def test_oserror_before_filenotfound(self):
@@ -470,6 +472,198 @@ class TestEnvelopeAndOptions(unittest.TestCase):
         findings = scan("def f(x=[]):\n    x.append(1)\n")
         for key in ("shape", "severity", "confidence", "file", "line", "message"):
             self.assertIn(key, findings[0])
+
+
+class TestExceptExceptionTooBroad(unittest.TestCase):
+    """The gist's #1 family: ~50% of 40 confirmed CPython stdlib findings."""
+
+    def test_narrow_body_swallowed_is_high(self):
+        src = (
+            "def f(o):\n    try:\n        x = o.a.b.c\n"
+            "    except Exception:\n        x = None\n    return x\n"
+        )
+        f = [x for x in scan(src) if x["shape"] == "except-exception-too-broad"]
+        self.assertEqual(f[0]["confidence"], "high")
+
+    def test_narrow_body_with_pass_is_high(self):
+        src = "def f(o):\n    try:\n        o.flush()\n    except Exception:\n        pass\n"
+        f = [x for x in scan(src) if x["shape"] == "except-exception-too-broad"]
+        self.assertEqual(f[0]["confidence"], "high")
+
+    def test_base_exception_also_flagged(self):
+        src = "def f(o):\n    try:\n        o.flush()\n    except BaseException:\n        pass\n"
+        self.assertIn("except-exception-too-broad", shapes(src))
+
+    def test_loud_logging_downgrades(self):
+        src = (
+            "import logging\nlog = logging.getLogger(__name__)\n"
+            "def f(o):\n    try:\n        o.flush()\n"
+            "    except Exception:\n        log.exception('failed')\n"
+        )
+        f = [x for x in scan(src) if x["shape"] == "except-exception-too-broad"]
+        self.assertEqual(f[0]["confidence"], "medium")
+
+    def test_large_body_boundary_is_low(self):
+        src = (
+            "def f(p):\n    try:\n        p.setup()\n        p.configure()\n"
+            "        p.start()\n        p.verify()\n    except Exception:\n        pass\n"
+        )
+        f = [x for x in scan(src) if x["shape"] == "except-exception-too-broad"]
+        self.assertEqual(f[0]["confidence"], "low")
+
+    def test_narrow_exception_type_is_silent(self):
+        src = (
+            "def f(o):\n    try:\n        return o.a.b\n"
+            "    except AttributeError:\n        return None\n"
+        )
+        self.assertNotIn("except-exception-too-broad", shapes(src))
+
+    def test_reraising_handler_is_silent(self):
+        src = "def f(o):\n    try:\n        o.flush()\n    except Exception:\n        raise\n"
+        self.assertNotIn("except-exception-too-broad", shapes(src))
+
+
+class TestCleanupOnlyOnSuccess(unittest.TestCase):
+    def test_close_last_in_try_is_flagged(self):
+        src = (
+            "def f(c):\n    try:\n        c.send(1)\n        c.check()\n"
+            "        c.close()\n    except OSError:\n        pass\n"
+        )
+        self.assertIn("cleanup-only-on-success-path", shapes(src))
+
+    def test_close_in_finally_is_silent(self):
+        src = (
+            "def f(c):\n    try:\n        c.send(1)\n    finally:\n        c.close()\n"
+        )
+        self.assertNotIn("cleanup-only-on-success-path", shapes(src))
+
+    def test_handler_also_closes_is_silent(self):
+        src = (
+            "def f(c):\n    try:\n        c.send(1)\n        c.close()\n"
+            "    except OSError:\n        c.close()\n"
+        )
+        self.assertNotIn("cleanup-only-on-success-path", shapes(src))
+
+    def test_non_release_call_is_silent(self):
+        src = (
+            "def f(c):\n    try:\n        c.send(1)\n        c.flush()\n"
+            "    except OSError:\n        pass\n"
+        )
+        self.assertNotIn("cleanup-only-on-success-path", shapes(src))
+
+
+class TestErrorReportedBelowWarning(unittest.TestCase):
+    def test_debug_only_is_flagged(self):
+        src = (
+            "import logging\nlog = logging.getLogger(__name__)\n"
+            "def f(o):\n    try:\n        o.decref()\n"
+            "    except Exception:\n        log.debug('failed')\n"
+        )
+        self.assertIn("error-reported-below-warning", shapes(src))
+
+    def test_warning_is_silent(self):
+        src = (
+            "import logging\nlog = logging.getLogger(__name__)\n"
+            "def f(o):\n    try:\n        o.decref()\n"
+            "    except Exception:\n        log.warning('failed')\n"
+        )
+        self.assertNotIn("error-reported-below-warning", shapes(src))
+
+    def test_reraise_is_silent(self):
+        src = (
+            "import logging\nlog = logging.getLogger(__name__)\n"
+            "def f(o):\n    try:\n        o.decref()\n"
+            "    except Exception:\n        log.debug('x')\n        raise\n"
+        )
+        self.assertNotIn("error-reported-below-warning", shapes(src))
+
+
+class TestExceptInLoopWithoutExit(unittest.TestCase):
+    def test_swallow_in_while_true_is_flagged(self):
+        src = (
+            "def f(p):\n    while True:\n        try:\n            return listdir(p)\n"
+            "        except OSError:\n            pass\n"
+        )
+        self.assertIn("except-in-loop-without-exit", shapes(src))
+
+    def test_break_in_handler_is_silent(self):
+        src = (
+            "def f(p):\n    while True:\n        try:\n            return listdir(p)\n"
+            "        except OSError:\n            break\n"
+        )
+        self.assertNotIn("except-in-loop-without-exit", shapes(src))
+
+    def test_raise_in_handler_is_silent(self):
+        src = (
+            "def f(p):\n    while True:\n        try:\n            return listdir(p)\n"
+            "        except OSError:\n            raise\n"
+        )
+        self.assertNotIn("except-in-loop-without-exit", shapes(src))
+
+    def test_queue_empty_poll_loop_is_silent(self):
+        # idlelib rpc.py/run.py: "nothing queued right now" is the design.
+        src = (
+            "import queue\ndef f(q):\n    while True:\n        try:\n"
+            "            msg = q.get(0)\n        except queue.Empty:\n            pass\n"
+            "        do_other_work()\n"
+        )
+        self.assertNotIn("except-in-loop-without-exit", shapes(src))
+
+    def test_timeout_poll_loop_is_silent(self):
+        src = (
+            "def f(s):\n    while True:\n        try:\n            return s.recv()\n"
+            "        except TimeoutError:\n            pass\n"
+        )
+        self.assertNotIn("except-in-loop-without-exit", shapes(src))
+
+    def test_oserror_scan_loop_still_flagged(self):
+        # The gist's genuine instance: a real failure, not a poll signal.
+        src = (
+            "def f(p):\n    while True:\n        try:\n            return listdir(p)\n"
+            "        except OSError:\n            pass\n"
+        )
+        self.assertIn("except-in-loop-without-exit", shapes(src))
+
+    def test_bounded_loop_is_silent(self):
+        src = (
+            "def f(p):\n    for _ in range(3):\n        try:\n            return listdir(p)\n"
+            "        except OSError:\n            pass\n"
+        )
+        self.assertNotIn("except-in-loop-without-exit", shapes(src))
+
+
+class TestRaiseWithoutFrom(unittest.TestCase):
+    def test_missing_from_is_flagged(self):
+        src = (
+            "def f(t):\n    try:\n        return int(t)\n"
+            "    except ValueError as err:\n        raise TypeError('bad')\n"
+        )
+        self.assertIn("raise-without-from-in-except", shapes(src))
+
+    def test_from_err_is_silent(self):
+        src = (
+            "def f(t):\n    try:\n        return int(t)\n"
+            "    except ValueError as err:\n        raise TypeError('bad') from err\n"
+        )
+        self.assertNotIn("raise-without-from-in-except", shapes(src))
+
+    def test_from_none_is_silent(self):
+        src = (
+            "def f(t):\n    try:\n        return int(t)\n"
+            "    except ValueError:\n        raise TypeError('bad') from None\n"
+        )
+        self.assertNotIn("raise-without-from-in-except", shapes(src))
+
+    def test_bare_reraise_is_silent(self):
+        src = "def f(t):\n    try:\n        return int(t)\n    except ValueError:\n        raise\n"
+        self.assertNotIn("raise-without-from-in-except", shapes(src))
+
+    def test_reraising_caught_name_is_silent(self):
+        src = (
+            "def f(t):\n    try:\n        return int(t)\n"
+            "    except ValueError as err:\n        raise err\n"
+        )
+        self.assertNotIn("raise-without-from-in-except", shapes(src))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Mapping the [40-bug CPython stdlib audit](https://gist.github.com/devdanzin/3198710e3c0128fda5e0a7b4e0768e5f) against our shape catalog showed we covered **none** of its pattern families. The existing `bare-except-swallows-control-flow` handles only bare `except:` / `except BaseException:` — a *different* shape from `except Exception:`, which alone was **~50% of that audit's 40 confirmed findings**.

Added five shapes, each with guarded twin, sibling-hunt directive, and differential:

| Shape | Share of the audit |
|---|---|
| `except-exception-too-broad` | ~50% (20 of 40) |
| `cleanup-only-on-success-path` | ~20% (8) |
| `error-reported-below-warning` | ~17% (7) |
| `except-in-loop-without-exit` | hang-class instance |
| `raise-without-from-in-except` | chaining |

Confidence for the big one keys on the shape of the guard: **narrow try body + silent handler = high**; narrow + loud log = medium; large body at a genuine boundary = low. That is the audit's own differential, encoded.

## Validated on the idlelib benchmark — one FP class found immediately

`while True: ... except queue.Empty: pass` (`rpc.py:424`, `run.py:166`) is an **event loop draining a queue**, not a hang. `queue.Empty` / `TimeoutError` / `socket.timeout` / `BlockingIOError` / `InterruptedError` mean *"nothing ready right now"*, not *"this failed"*.

Added `_is_poll_signal()` — the discriminator is the exception's **meaning**, not the loop shape. The gist's genuine instance (`except OSError:` on a directory scan) is still flagged. Recorded as taxonomy class 21.

## Result on idlelib

73 findings, 32 high-confidence (from 58/28 before). The new shapes contribute four `except-exception-too-broad` sites and three `cleanup-only-on-success-path`.

## Test plan

- [x] **466 tests pass** (was 440) — 26 new, covering true positive + guarded twin + edge case per shape
- [x] Guarded-twin fixture for all five: narrow `except AttributeError:`, `finally: close()`, `log.warning`, `raise ... from err`, `break` in handler — none fire
- [x] `ruff check` / `ruff format --check` clean
- [x] Re-ran idlelib after each change to confirm the FP class was eliminated and true positives survived

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oHTKJMM4ThdosDumvAFek