### PR TITLE
Add flag-not-reset-on-early-exit, found by the idlelib benchmark

### DIFF
--- a/plugins/code-review-toolkit/data/python_bug_shapes.json
+++ b/plugins/code-review-toolkit/data/python_bug_shapes.json
@@ -351,13 +351,36 @@
       "hunt": "Every `raise` inside an `except` in the module; the convention is applied per-codebase, so a module that chains in one place and not another has a real inconsistency.",
       "expected": "the traceback shows the original cause, explicitly marked as cause or deliberately suppressed.",
       "caught_as": "Visible in the traceback as 'During handling of the above exception, another exception occurred' rather than 'The above exception was the direct cause' -- confusing rather than silent, but it degrades every downstream diagnosis.",
-      "confirmed_examples": [],
-      "validation": "documented",
+      "confirmed_examples": [
+        "CPython idlelib (6080c86): ALL SIX raise-inside-except sites lack `from` -- config.py:211, pyshell.py:12, rpc.py:345, rpc.py:361, run.py:360, zoomheight.py:74. rpc.py:361 (`except OSError: raise EOFError`) is the costly one: it discards the errno, so there is no record of whether IDLE restarted because the peer exited or because the kernel ran out of buffers. Found by reports/idlelib_v1."
+      ],
+      "validation": "confirmed",
       "references": [
         "Derived from a 40-bug audit of CPython's pure-Python stdlib (gist 3198710e3c0128fda5e0a7b4e0768e5f), where this family accounted for the pickle.py instance, where a traceback object is passed as a constructor argument instead of being chained.",
         "ruff B904 raise-without-from-inside-except"
       ],
       "differential": "Not a defect when the new exception is genuinely unrelated to the caught one and `from None` would be noise, or in code targeting Python 2 compatibility. Judge by whether the original would help someone debugging.",
+      "detected_by": "scan_python_pitfalls.py"
+    },
+    {
+      "id": "flag-not-reset-on-early-exit",
+      "title": "Guard flag set at entry but reset only on the success path",
+      "agent": "python-pitfall-scanner",
+      "severity": "FIX",
+      "pattern": "A method sets a persistent guard flag (`self.busy = True`, `self.restarting = True`) to mark work in progress, then resets it (`= False`) as the last statement -- with one or more `return`/`raise` between them that skip the reset. The flag stays set for the object's lifetime.",
+      "guarded_twin": "`try: self.busy = True; ...work... finally: self.busy = False`. This twin is almost always already present on a sibling method, because the author got it right somewhere else.",
+      "hunt": "Grep every `self.<name> = True`/`= False` pair in the class, then every early `return` between them. Also check the guard's READERS: the damage is proportional to how many entry points consult the flag.",
+      "expected": "the flag reflects reality on every path, so a later call proceeds normally.",
+      "caught_as": "SILENT and PERMANENT -- every subsequent call takes the 'already in progress' branch and returns immediately, doing nothing and reporting nothing. Looks like a frozen or unresponsive component, not an error.",
+      "confirmed_examples": [
+        "CPython idlelib pyshell.py:488 (6080c86) -- `self.restarting` set at 488, reset only at 526; a TimeoutError from `rpcclt.accept()` returns at 508, so IDLE can never restart its subprocess again: Run Module, Restart Shell and the auto-restart all hit the guard and silently do nothing. Found by reports/idlelib_v1.",
+        "CPython idlelib autocomplete_w.py:238 -- `self.is_configuring` set at 238, reset only at 284; `if not self.is_active(): return` at 240 skips it, permanently disabling the <Configure> handler for that completion window."
+      ],
+      "validation": "confirmed",
+      "references": [
+        "idlelib contains five correct twins of this idiom: debugger.py:153 (self.interacting), colorizer.py:265 (self.colorizing), run.py:588 (interruptible), pyshell.py:1174 (self.reading), sidebar.py:57 (temp_enable_text_widget)."
+      ],
+      "differential": "Only state that OUTLIVES the call matters -- an attribute or a qualified global. Re-binding a bare LOCAL is ordinary computation, not a missed reset. Also fine if a `finally` elsewhere in the function restores it, or if the early exit happens BEFORE the flag is set.",
       "detected_by": "scan_python_pitfalls.py"
     }
   ]

--- a/plugins/code-review-toolkit/scripts/scan_python_pitfalls.py
+++ b/plugins/code-review-toolkit/scripts/scan_python_pitfalls.py
@@ -1230,6 +1230,85 @@ def _check_raise_without_from(tree: ast.AST) -> list[dict]:
     return out
 
 
+def _flag_assignments(fn: ast.AST) -> dict[str, list[tuple[int, ast.AST]]]:
+    """Map `self.attr` / bare-name targets to their constant assignments."""
+    found: dict[str, list[tuple[int, ast.AST]]] = {}
+    for node in _walk_same_scope(fn):
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        if not isinstance(node.value, ast.Constant):
+            continue
+        target = node.targets[0]
+        name = _dotted_name(target)
+        # Only state that OUTLIVES the call can wedge anything -- an attribute
+        # (`self.busy`) or a qualified global. A bare local dies with the frame,
+        # so re-binding it is ordinary computation, not a missed reset.
+        if not name or "." not in name:
+            continue
+        found.setdefault(name, []).append((node.lineno, node))
+    return found
+
+
+def _check_flag_not_reset_on_early_exit(tree: ast.AST) -> list[dict]:
+    """A guard flag set at entry but reset only on the success path.
+
+    `self.busy = True` ... early `return` ... `self.busy = False` at the end
+    leaves the flag stuck for the object's lifetime, so every later call takes
+    the "already busy" branch and silently does nothing. The correct form --
+    `try: ... finally: self.busy = False` -- usually exists on a sibling method
+    already (idlelib has five, e.g. `Debugger.run`'s `self.interacting`).
+    """
+    out: list[dict] = []
+    for fn in ast.walk(tree):
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        # A finally that touches the flag discharges the obligation.
+        guarded_in_finally: set[str] = set()
+        for node in ast.walk(fn):
+            if isinstance(node, ast.Try):
+                for stmt in node.finalbody:
+                    for inner in ast.walk(stmt):
+                        if isinstance(inner, ast.Assign):
+                            for tgt in inner.targets:
+                                nm = _dotted_name(tgt)
+                                if nm:
+                                    guarded_in_finally.add(nm)
+        for name, assigns in _flag_assignments(fn).items():
+            if name in guarded_in_finally or len(assigns) < 2:
+                continue
+            set_line, set_node = assigns[0]
+            reset_line, _reset_node = assigns[-1]
+            if reset_line <= set_line:
+                continue
+            # Different values: a set/reset pair, not two writes of the same value.
+            values = {a[1].value.value for a in (assigns[0], assigns[-1])}  # type: ignore[attr-defined]
+            if len(values) < 2:
+                continue
+            # An exit between them skips the reset.
+            exits = [
+                n
+                for n in _walk_same_scope(fn)
+                if isinstance(n, (ast.Return, ast.Raise))
+                and set_line < n.lineno < reset_line
+            ]
+            if not exits:
+                continue
+            out.append(
+                _finding(
+                    "flag-not-reset-on-early-exit",
+                    "FIX",
+                    "high",
+                    set_node,
+                    f"`{name}` is set at line {set_line} but reset only at line "
+                    f"{reset_line}; {len(exits)} earlier exit(s) skip the reset",
+                    "the flag stays set for the object's lifetime, so every later "
+                    "call takes the guarded branch and silently does nothing -- "
+                    "use `try: ... finally:` to restore it on every path",
+                )
+            )
+    return out
+
+
 _CHECKS = {
     "mutable-default-argument": _check_mutable_default,
     "late-binding-closure-in-loop": _check_late_binding_closure,
@@ -1250,6 +1329,7 @@ _CHECKS = {
     "error-reported-below-warning": _check_error_reported_below_warning,
     "except-in-loop-without-exit": _check_except_in_loop_without_exit,
     "raise-without-from-in-except": _check_raise_without_from,
+    "flag-not-reset-on-early-exit": _check_flag_not_reset_on_early_exit,
 }
 
 

--- a/tests/test_scan_python_pitfalls.py
+++ b/tests/test_scan_python_pitfalls.py
@@ -666,5 +666,49 @@ class TestRaiseWithoutFrom(unittest.TestCase):
         self.assertNotIn("raise-without-from-in-except", shapes(src))
 
 
+class TestFlagNotResetOnEarlyExit(unittest.TestCase):
+    """idlelib pyshell.py:488 -- a stuck guard flag wedges the component."""
+
+    def test_early_return_skips_reset(self):
+        src = (
+            "class C:\n    def go(self):\n        if self.busy:\n            return\n"
+            "        self.busy = True\n        if not self.ready():\n            return\n"
+            "        self.work()\n        self.busy = False\n"
+        )
+        f = [x for x in scan(src) if x["shape"] == "flag-not-reset-on-early-exit"]
+        self.assertEqual(len(f), 1)
+        self.assertEqual(f[0]["confidence"], "high")
+
+    def test_finally_reset_is_silent(self):
+        src = (
+            "class C:\n    def go(self):\n        try:\n            self.busy = True\n"
+            "            if not self.ready():\n                return\n            self.work()\n"
+            "        finally:\n            self.busy = False\n"
+        )
+        self.assertNotIn("flag-not-reset-on-early-exit", shapes(src))
+
+    def test_no_early_exit_is_silent(self):
+        src = (
+            "class C:\n    def go(self):\n        self.busy = True\n"
+            "        self.work()\n        self.busy = False\n"
+        )
+        self.assertNotIn("flag-not-reset-on-early-exit", shapes(src))
+
+    def test_local_variable_is_silent(self):
+        # A bare local dies with the frame -- rebinding it wedges nothing.
+        src = (
+            "def f(t):\n    line = t.get()\n    if not line:\n        return None\n"
+            "    line = ''\n    return line\n"
+        )
+        self.assertNotIn("flag-not-reset-on-early-exit", shapes(src))
+
+    def test_same_value_twice_is_silent(self):
+        src = (
+            "class C:\n    def go(self):\n        self.x = True\n"
+            "        if self.q():\n            return\n        self.x = True\n"
+        )
+        self.assertNotIn("flag-not-reset-on-early-exit", shapes(src))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

The silent-failure agent's **systemic** finding on idlelib was that the dominant defect family there is *not* broad exception catches — idlelib has only three `except Exception:` in non-test code — but **state restored on the success path instead of in `finally`**.

`cleanup-only-on-success-path` covers the resource-release variant (`close`/`quit`/`shutdown`). This adds the **guard-flag** variant, which has a worse failure mode: the flag stays set for the object's lifetime, so every later call takes the "already in progress" branch and **silently does nothing**.

## Confirmed instances

- **`pyshell.py:488`** — `self.restarting` is set at 488 but reset only at 526. A `TimeoutError` from `rpcclt.accept()` returns at 508. IDLE can then **never restart its subprocess again**: Run Module, Restart Shell, and the auto-restart all hit the guard at line 486 and return instantly with no error. IDLE looks alive but can't run code; only quitting fixes it.
- **`autocomplete_w.py:238`** — `self.is_configuring` set at 238, reset at 284, with `if not self.is_active(): return` at 240 skipping it. Permanently disables the `<Configure>` handler for that completion window. **The agent did not report this one — the scanner found it.**

## Calibration

The first draft also flagged bare **locals** (`pyshell.py:1185` rebinding `line`). That's ordinary computation: a local dies with the frame and can wedge nothing. Restricted to state that *outlives* the call — an attribute or qualified global.

idlelib contains **five correct twins** of the idiom (`debugger.py:153`, `colorizer.py:265`, `run.py:588`, `pyshell.py:1174`, `sidebar.py:57`), which makes the omissions defects by the project's own standard rather than a style preference.

Also promotes `raise-without-from-in-except` to `validation: confirmed` — all six raise-inside-except sites in idlelib lack `from`, and `rpc.py:361` discards the errno that would say *why* the connection was declared dead.

## Test plan

- [x] **471 tests pass** (was 466) — 5 new: true positive, `finally` twin, no-early-exit, bare-local, same-value-twice
- [x] Verified against the real sites in `pyshell.py` and `autocomplete_w.py`
- [x] `ruff check` / `ruff format --check` clean

Catalog is now **20 shapes, 2 confirmed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oHTKJMM4ThdosDumvAFek